### PR TITLE
Move AMP visual settings to the Customizer

### DIFF
--- a/assets/js/customizer-controls.js
+++ b/assets/js/customizer-controls.js
@@ -1,0 +1,42 @@
+(function (api) {
+	// bind to the correct section
+	api.section('amp_design_settings', function (section) {
+		// bind to when the section is expanded (or closed)
+		section.expanded.bind(function (isExpanded) {
+
+			var url;
+
+			// if it's expanded
+			if (isExpanded) {
+
+				// strip trailing slash from the current preview URL
+				url = api.previewer.previewUrl.get().replace(/\/$/, "");
+
+				// add /amp/ if necessary
+				if (!url.endsWith('/amp/')) {
+					url += '/amp/';
+				}
+
+				// navigate to the Amp version of the post
+				console.log('Navigating the preview frame to ' + url);
+				api.previewer.previewUrl.set(url);
+
+			} else {
+
+				// get the current preview URL
+				url = api.previewer.previewUrl.get();
+
+				// if it's an amp version, remove /amp/
+				if (url.endsWith('/amp/')) {
+					url = url.replace(/\/amp\/$/, "");
+				}
+
+				// navigate to the standard version of the post
+				console.log('Navigating the preview frame to ' + url);
+				api.previewer.previewUrl.set(url);
+
+			}
+
+		});
+	});
+}(wp.customize) );

--- a/assets/js/customizer-controls.js
+++ b/assets/js/customizer-controls.js
@@ -1,41 +1,57 @@
 (function (api) {
-	// bind to the correct section
-	api.section('amp_design_settings', function (section) {
-		// bind to when the section is expanded (or closed)
+	function showHideAMPurl(isExpanded){
+		var url;
+
+		// if it's expanded
+		if (isExpanded) {
+
+			// strip trailing slash from the current preview URL
+			url = api.previewer.previewUrl.get().replace(/\/$/, "");
+
+			// add /amp/ if necessary
+			if (!url.endsWith('/amp/')) {
+				url += '/amp/';
+			}
+
+			// navigate to the Amp version of the post
+			console.log('Navigating the preview frame to ' + url);
+			api.previewer.previewUrl.set(url);
+
+		} else {
+
+			// get the current preview URL
+			url = api.previewer.previewUrl.get();
+
+			// if it's an amp version, remove /amp/
+			if (url.endsWith('/amp/')) {
+				url = url.replace(/\/amp\/$/, "");
+			}
+
+			// navigate to the standard version of the post
+			console.log('Navigating the preview frame to ' + url);
+			api.previewer.previewUrl.set(url);
+
+		}
+	}
+
+
+	// bind to the AMP sections
+	api.section('wpseo_amp_design_settings', function (section) {
+		// bind to when the section is expanded
 		section.expanded.bind(function (isExpanded) {
 
-			var url;
+			// show or hide the AMP version
+			showHideAMPurl(isExpanded);
 
-			// if it's expanded
-			if (isExpanded) {
+		});
+	});
 
-				// strip trailing slash from the current preview URL
-				url = api.previewer.previewUrl.get().replace(/\/$/, "");
+	api.section('wpseo_amp_advanced_settings', function (section) {
+		// bind to when the section is expanded
+		section.expanded.bind(function (isExpanded) {
 
-				// add /amp/ if necessary
-				if (!url.endsWith('/amp/')) {
-					url += '/amp/';
-				}
-
-				// navigate to the Amp version of the post
-				console.log('Navigating the preview frame to ' + url);
-				api.previewer.previewUrl.set(url);
-
-			} else {
-
-				// get the current preview URL
-				url = api.previewer.previewUrl.get();
-
-				// if it's an amp version, remove /amp/
-				if (url.endsWith('/amp/')) {
-					url = url.replace(/\/amp\/$/, "");
-				}
-
-				// navigate to the standard version of the post
-				console.log('Navigating the preview frame to ' + url);
-				api.previewer.previewUrl.set(url);
-
-			}
+			// show or hide the AMP version
+			showHideAMPurl(isExpanded);
 
 		});
 	});

--- a/assets/js/customizer-preview.js
+++ b/assets/js/customizer-preview.js
@@ -1,0 +1,24 @@
+// if wp.customize exists
+if ('undefined' !== typeof wp && wp.customize) {
+
+	// wait for window load - no iframe ready event (yet)
+	jQuery(window).load(function () {
+
+		// loop through all the CSS selectors
+		jQuery.each(wpseoCSSselectors, function (key, cssValues) {
+
+			// bind each one to the correct option
+			wp.customize('wpseo_amp[' + key + ']', function (value) {
+
+				// update the CSS selector on value change
+				value.bind(function (newval) {
+						jQuery(cssValues.selector).css(cssValues.property, newval);
+				});
+
+			});
+
+		});
+
+	});
+
+}

--- a/classes/class-customizer.php
+++ b/classes/class-customizer.php
@@ -1,0 +1,477 @@
+<?php
+/**
+ * @package     YoastSEO_AMP_Glue\Options
+ * @author      Andrew Taylor
+ * @license     GPL-2.0+
+ */
+
+if ( ! class_exists( 'YoastSEO_AMP_Customizer' ) ) {
+
+	class YoastSEO_AMP_Customizer {
+
+		/** @var string Name of the option in the database */
+		private $option_name = 'wpseo_amp';
+
+		/** @var array Option defaults */
+		private $defaults = array(
+			'version'                 => 1,
+			'amp_site_icon'           => '',
+			'default_image'           => '',
+			'header-color'            => '',
+			'headings-color'          => '',
+			'text-color'              => '',
+			'meta-color'              => '',
+			'link-color'              => '',
+			'link-color-hover'        => '',
+			'underline'               => 'underline',
+			'blockquote-text-color'   => '',
+			'blockquote-bg-color'     => '',
+			'blockquote-border-color' => '',
+			'extra-css'               => '',
+			'extra-head'              => '',
+		);
+
+		/** @var self Class instance */
+		private static $instance;
+
+		/**
+		 * @return YoastSEO_AMP_Customizer
+		 */
+		public static function get_instance() {
+			if ( ! isset( self::$instance ) ) {
+				self::$instance = new self();
+			}
+
+			return self::$instance;
+		}
+
+		private function __construct() {
+			add_action( 'customize_register', array( $this, 'amp_customizer_settings' ) );
+			add_action( 'wp_enqueue_scripts', array( $this, 'amp_customizer_preview_enqueue' ) );
+			add_action( 'customize_controls_enqueue_scripts', array( $this, 'amp_customizer_controls_enqueue' ) );
+		}
+
+		/**
+		 * Sanitize link underline option
+		 *
+		 * @param string $input Raw input.
+		 *
+		 * @return string|false Sanitized input.
+		 */
+		public function sanitize_link_underline( $input ) {
+			return ( 'underline' === $input ) ? $input : false;
+		}
+
+		/**
+		 * Sanitize extra CSS
+		 *
+		 * @param string $input Raw input.
+		 *
+		 * @return string Sanitized input.
+		 */
+		public function sanitize_css( $input ) {
+			$extra_css = strip_tags( $input );
+			$extra_css = wp_check_invalid_utf8( $extra_css );
+			$extra_css = _wp_specialchars( $extra_css, ENT_NOQUOTES );
+
+			return $extra_css;
+		}
+
+		/**
+		 * Sanitize extra <head> code
+		 *
+		 * @param string $input Raw input.
+		 *
+		 * @return string Sanitized input.
+		 */
+		public function sanitize_extra_head( $input ) {
+			// Only allow meta and link tags in head.
+			return strip_tags( $input, '<link><meta>' );
+		}
+
+		/**
+		 * Validate extra <head> code
+		 *
+		 * @param object $validity validity object.
+		 * @param mixed  $value    user inputted value.
+		 *
+		 * @return object $validity
+		 */
+		public function validate_extra_head( $validity, $value ) {
+			if ( ! empty( $value ) ) {
+				if ( 1 === preg_match( '/<[^link|meta]/', $value ) ){
+					$validity->add( 'invalid-code', sprintf( esc_html( __( 'Only %1$s and %2$s tags are allowed', 'wordpress-seo' ) ), '<link>', '<meta>' ) );
+				}
+			}
+
+			return $validity;
+		}
+
+		/**
+		 * Validate the Amp site icon
+		 *
+		 * @param object $validity validity object.
+		 * @param mixed  $value    user inputted value.
+		 *
+		 * @return object $validity
+		 */
+		function sanitize_amp_site_icon( $validity, $value ) {
+			if ( ! empty( $value ) ) {
+				$image_atts = wp_get_attachment_metadata( $value );
+				if ( false !== $image_atts ) {
+					if ( $image_atts['width'] < 32 || $image_atts['height'] < 32 ){
+						$validity->add( 'image-size', __( 'The amp icon needs to be at least 32px &times; 32px', 'wordpress-seo' ) );
+					}
+					if ( $image_atts['width'] !== $image_atts['height'] ){
+						$validity->add( 'image-size', __( 'The amp icon needs to have the same width and height', 'wordpress-seo' ) );
+					}
+				}
+			}
+
+			return $validity;
+		}
+
+		/**
+		 * Validate the Amp default image
+		 *
+		 * @param object $validity validity object.
+		 * @param mixed  $value    user inputted value.
+		 *
+		 * @return object $validity
+		 */
+		function sanitize_amp_default_image( $validity, $value ) {
+			if ( ! empty( $value ) ) {
+				$image_atts = wp_get_attachment_metadata( $value );
+				if ( false !== $image_atts && $image_atts['width'] < 696 ) {
+						$validity->add( 'image-size', __( 'The amp default image needs to be at least 696px wide', 'wordpress-seo' ) );
+				}
+			}
+
+			return $validity;
+		}
+
+		/**
+		 * Add AMP Customizer panel, sections and settings/controls
+		 *
+		 * @param object $wp_customize an instance of the WP_Customize_Manager class.
+		 */
+		public function amp_customizer_settings( $wp_customize ) {
+			$default_labels = array(
+				// Design settings
+				'amp_site_icon'           => __( 'AMP icon', 'wordpress-seo' ),
+				'default_image'           => __( 'Default image', 'wordpress-seo' ),
+				'underline'               => __( 'Link underline', 'wordpress-seo' ),
+
+				// Color settings
+				'header-color'            => __( 'AMP Header color', 'wordpress-seo' ),
+				'headings-color'          => __( 'Title color', 'wordpress-seo' ),
+				'text-color'              => __( 'Text color', 'wordpress-seo' ),
+				'meta-color'              => __( 'Post meta info color', 'wordpress-seo' ),
+				'link-color'              => __( 'Link text color', 'wordpress-seo' ),
+				'link-color-hover'        => __( 'link hover color', 'wordpress-seo' ),
+				'blockquote-text-color'   => __( 'Blockquote text color', 'wordpress-seo' ),
+				'blockquote-bg-color'     => __( 'Blockquote background color', 'wordpress-seo' ),
+				'blockquote-border-color' => __( 'Blockquote border color', 'wordpress-seo' ),
+
+				// Advanced settings
+				'extra-css'               => __( 'Extra CSS', 'wordpress-seo' ),
+				'extra-head'              => sprintf( esc_html( __( 'Extra code in %s', 'wordpress-seo' ) ), '&lt;head&gt;' ),
+			);
+
+			/**
+			 * Adds a panel for the AMP settings
+			 *
+			 * @link https://developer.wordpress.org/themes/advanced-topics/customizer-api/#panels
+			 */
+			$wp_customize->add_panel( 'wpseo_amp_settings', array(
+				'title'       => __( 'AMP Settings', 'wordpress-seo' ),
+				'description' => '<p>' . __( 'Options for the Yoast AMP SEO glue plugin.', 'wordpress-seo' ) . '</p>',
+				'priority'    => 160,
+			) );
+
+			/*
+			 * Add a design section to the AMP settings panel.
+			 *
+			 * @link https://developer.wordpress.org/themes/advanced-topics/customizer-api/#sections
+			 */
+			$wp_customize->add_section(
+			// Use a unique, descriptive section slug to avoid conflicts.
+				'wpseo_amp_design_settings',
+				array(
+					'title'           => __( 'AMP Design Settings', 'wordpress-seo' ),
+					// Add the section to our custom panel.
+					'panel'           => 'wpseo_amp_settings',
+					// Only display the section if previewing an Amp supported post
+					'active_callback' => array( $this, 'amp_post_support_callback' ),
+				)
+			);
+
+			/**
+			 * Add a field to the Customizer for the Amp site icon.
+			 *
+			 * @link https://developer.wordpress.org/themes/advanced-topics/customizer-api/#core-custom-controls
+			 */
+			$wp_customize->add_setting( $this->option_name . '[amp_site_icon]', array(
+				'capability'        => 'manage_options',
+				'type'              => 'theme_mod',
+				'sanitize_callback' => 'absint',
+				// Reload the entire page to get the new icon
+				'transport'         => 'reload',
+				'validate_callback' => array( $this, 'sanitize_amp_site_icon' ),
+			) );
+
+			$wp_customize->add_control(
+				new WP_Customize_Media_Control(
+					$wp_customize,
+					$this->option_name . '[amp_site_icon]',
+					array(
+						'label'       => $default_labels['amp_site_icon'],
+						'description' => __( 'Must be at least 32px &times; 32px', 'wordpress-seo' ),
+						'section'     => 'wpseo_amp_design_settings',
+						'mime_type'   => 'image',
+						'width'       => 32,
+						'height'      => 32,
+					)
+				)
+			);
+
+			/**
+			 * Add a field to the Customizer for the Amp default image.
+			 *
+			 * @link https://developer.wordpress.org/themes/advanced-topics/customizer-api/#core-custom-controls
+			 */
+			$wp_customize->add_setting( $this->option_name . '[default_image]', array(
+				'capability'        => 'manage_options',
+				'type'              => 'theme_mod',
+				'sanitize_callback' => 'absint',
+				// Reload the entire page to get the default image
+				'transport'         => 'reload',
+				'validate_callback' => array( $this, 'sanitize_amp_default_image' ),
+			) );
+
+			$wp_customize->add_control(
+				new WP_Customize_Media_Control(
+					$wp_customize,
+					$this->option_name . '[default_image]',
+					array(
+						'label'       => $default_labels['default_image'],
+						'description' => __( 'The image must be at least 696px wide.', 'wordpress-seo' ),
+						'section'     => 'wpseo_amp_design_settings',
+						'mime_type'   => 'image',
+						'width'       => 696,
+					)
+				)
+			);
+
+			/*
+			 * Bulk add color a field for each color setting to the Customizer.
+			 */
+			foreach ( $default_labels as $key => $label ) {
+				// Skip items that aren't colors
+				if ( false === stripos( $key, 'color' ) ) {
+					continue;
+				}
+
+				$option_name = $this->option_name . '[' . $key . ']';
+				$default     = $this->defaults[ $key ];
+
+				// Register each setting with the Customizer
+				$wp_customize->add_setting( $option_name, array(
+					'capability'        => 'manage_options',
+					'type'              => 'option',
+					'default'           => $default,
+					'sanitize_callback' => 'sanitize_hex_color',
+					'transport'         => 'postMessage',
+				) );
+
+				// Add a Customizer control for each setting.
+				$wp_customize->add_control(
+					new WP_Customize_Color_Control(
+						$wp_customize,
+						$option_name,
+						array(
+							'priority' => 10,
+							'section'  => 'wpseo_amp_design_settings',
+							'label'    => $label,
+							'default'  => $default,
+						)
+					)
+				);
+
+			}
+
+			/**
+			 * Add a field to the Customizer for the link underline setting.
+			 */
+			$wp_customize->add_setting( $this->option_name . '[underline]', array(
+				'capability'        => 'manage_options',
+				'type'              => 'option',
+				'default'           => 'underline',
+				'sanitize_callback' => array( $this, 'sanitize_link_underline' ),
+				'transport'         => 'postMessage',
+			) );
+
+			$wp_customize->add_control( $this->option_name . '[underline]', array(
+					'type'    => 'radio',
+					'section' => 'wpseo_amp_design_settings',
+					'label'   => $default_labels['underline'],
+					'choices' => array(
+						'underline' => __( 'Enabled', 'wordpress-seo' ),
+						false => __( 'Disabled', 'wordpress-seo' ),
+					),
+				)
+			);
+
+
+			/*
+			 * Add an advanced section to the AMP settings panel.
+			 *
+			 * @link https://developer.wordpress.org/themes/advanced-topics/customizer-api/#sections
+			 */
+			$wp_customize->add_section(
+			// Use a unique, descriptive section slug to avoid conflicts.
+				'wpseo_amp_advanced_settings',
+				array(
+					'title'           => __( 'AMP Advanced Settings', 'wordpress-seo' ),
+					// Add the section to our custom panel.
+					'panel'           => 'wpseo_amp_settings',
+					// Only display the section if previewing an Amp supported post
+					'active_callback' => array( $this, 'amp_post_support_callback' ),
+				)
+			);
+
+			/**
+			 * Add a field to the Customizer for the custom CSS setting.
+			 */
+			$wp_customize->add_setting( $this->option_name . '[extra-css]', array(
+				'capability'        => 'manage_options',
+				'type'              => 'option',
+				'default'           => '',
+				'sanitize_callback' => array( $this, 'sanitize_css' ),
+				// full page reload to get inline CSS
+				'transport'         => 'reload',
+			) );
+
+			$wp_customize->add_control( $this->option_name . '[extra-css]', array(
+					'type'    => 'textarea',
+					'section' => 'wpseo_amp_advanced_settings',
+					'label'   => $default_labels['extra-css'],
+				)
+			);
+
+			/**
+			 * Add a field to the Customizer for the extra <head> code setting.
+			 */
+			$wp_customize->add_setting( $this->option_name . '[extra-head]', array(
+				'capability'        => 'manage_options',
+				'type'              => 'option',
+				'default'           => '',
+				'sanitize_callback' => array( $this, 'sanitize_extra_head' ),
+				'validate_callback' => array( $this, 'validate_extra_head' ),
+				// full page reload to get updated <head>
+				'transport'         => 'reload',
+			) );
+
+			$wp_customize->add_control( $this->option_name . '[extra-head]', array(
+					'type'    => 'textarea',
+					'section' => 'wpseo_amp_advanced_settings',
+					'label'   => $default_labels['extra-head'],
+				)
+			);
+
+			/*
+			 * Add a section to the AMP settings panel if settings are unavailable die to viewing a non-amp post.
+			 *
+			 * @link https://developer.wordpress.org/themes/advanced-topics/customizer-api/#sections
+			 */
+			$wp_customize->add_section(
+			// Use a unique, descriptive section slug to avoid conflicts.
+				'wpseo_amp_settings_unavailable',
+				array(
+					'title'           => __( 'AMP Settings Unavailable', 'wordpress-seo' ),
+					'description'     => '<h3>' . __( 'AMP settings are not available for this post type. Try navigating to a standard post.', 'wordpress-seo' ) . '</h3>',
+					// Add the section to our custom panel.
+					'panel'           => 'wpseo_amp_settings',
+					// Only display the section if previewing a post without Amp support
+					'active_callback' => array( $this, 'amp_post_anti_support_callback' ),
+				)
+			);
+
+			// We need a control in the section so it displays but we'll keep it hidden
+			$wp_customize->add_setting( '_amp_hidden', array(
+				'capability' => 'manage_options',
+				'type'       => 'option',
+				'default'    => false,
+			) );
+
+			$wp_customize->add_control( '_amp_hidden', array(
+				'type'     => 'hidden',
+				'priority' => 10,
+				'section'  => 'wpseo_amp_settings_unavailable',
+			) );
+
+		}
+
+		/*
+		 * Returns true if the current post type has Amp support
+		 * otherwise, returns false.
+		 *
+		 * @return bool
+		 */
+		public function amp_post_support_callback() {
+			$amp_post_types = get_post_types_by_support( 'amp' );
+
+			$current_post_type = get_post_type();
+
+			return in_array( $current_post_type, $amp_post_types );
+
+		}
+
+		/*
+		 * Returns false if the current post type has Amp support
+		 * otherwise, returns true.
+		 *
+		 * @return bool
+		 */
+		public function amp_post_anti_support_callback() {
+			return ! $this->amp_post_support_callback();
+
+		}
+
+		/*
+		 * Enqueue JavaScript for use with the Customizer postMessage transport.
+		 *
+		 * if_customize_preview is used so we don't enqueue this script outside of the Customizer, where it isn't needed.
+		 *
+		 * @link https://developer.wordpress.org/themes/advanced-topics/customizer-api/#using-postmessage-for-improved-setting-previewing
+		 */
+		public function amp_customizer_preview_enqueue() {
+			if ( is_customize_preview() ) {
+				wp_enqueue_script( 'wpseo-amp-customizer-preview-script', YoastSEO_AMP_PLUGIN_DIR_URL . '/assets/js/customizer-preview.js', array(
+					'jquery',
+					'customize-preview',
+				), false, true );
+
+				if ( ! class_exists( 'YoastSEO_AMP_Frontend' ) ) {
+					require_once( YoastSEO_AMP_PLUGIN_DIR . 'classes/class-frontend.php' );
+				}
+
+				$wpseo_css_selectors = YoastSEO_AMP_Frontend::get_css_selectors();
+
+				wp_localize_script( 'wpseo-amp-customizer-preview-script', 'wpseoCSSselectors', $wpseo_css_selectors );
+			}
+		}
+
+		/*
+		 * Enqueue JavaScript for use with the Customizer controls.
+		 *
+		 * @link https://developer.wordpress.org/themes/advanced-topics/customizer-api/#using-postmessage-for-improved-setting-previewing
+		 */
+		public function amp_customizer_controls_enqueue() {
+			wp_enqueue_script( 'wpseo-amp-customizer-controls-script', YoastSEO_AMP_PLUGIN_DIR_URL . 'assets/js/customizer-controls.js', array(
+				'jquery',
+				'customize-controls',
+			), false, true );
+		}
+	}
+}

--- a/classes/class-customizer.php
+++ b/classes/class-customizer.php
@@ -47,7 +47,7 @@ if ( ! class_exists( 'YoastSEO_AMP_Customizer' ) ) {
 
 		private function __construct() {
 			add_action( 'customize_register', array( $this, 'amp_customizer_settings' ) );
-			add_action( 'wp_enqueue_scripts', array( $this, 'amp_customizer_preview_enqueue' ) );
+			add_action( 'amp_post_template_footer', array( $this, 'amp_customizer_preview_enqueue' ) );
 			add_action( 'customize_controls_enqueue_scripts', array( $this, 'amp_customizer_controls_enqueue' ) );
 		}
 
@@ -56,10 +56,10 @@ if ( ! class_exists( 'YoastSEO_AMP_Customizer' ) ) {
 		 *
 		 * @param string $input Raw input.
 		 *
-		 * @return string|false Sanitized input.
+		 * @return string Sanitized input.
 		 */
 		public function sanitize_link_underline( $input ) {
-			return ( 'underline' === $input ) ? $input : false;
+			return ( 'underline' === $input ) ? $input : 'none';
 		}
 
 		/**
@@ -168,7 +168,7 @@ if ( ! class_exists( 'YoastSEO_AMP_Customizer' ) ) {
 				'text-color'              => __( 'Text color', 'wordpress-seo' ),
 				'meta-color'              => __( 'Post meta info color', 'wordpress-seo' ),
 				'link-color'              => __( 'Link text color', 'wordpress-seo' ),
-				'link-color-hover'        => __( 'link hover color', 'wordpress-seo' ),
+				'link-color-hover'        => __( 'Link hover color', 'wordpress-seo' ),
 				'blockquote-text-color'   => __( 'Blockquote text color', 'wordpress-seo' ),
 				'blockquote-bg-color'     => __( 'Blockquote background color', 'wordpress-seo' ),
 				'blockquote-border-color' => __( 'Blockquote border color', 'wordpress-seo' ),
@@ -317,7 +317,7 @@ if ( ! class_exists( 'YoastSEO_AMP_Customizer' ) ) {
 					'label'   => $default_labels['underline'],
 					'choices' => array(
 						'underline' => __( 'Enabled', 'wordpress-seo' ),
-						false => __( 'Disabled', 'wordpress-seo' ),
+						'none' => __( 'Disabled', 'wordpress-seo' ),
 					),
 				)
 			);

--- a/classes/class-customizer.php
+++ b/classes/class-customizer.php
@@ -99,7 +99,7 @@ if ( ! class_exists( 'YoastSEO_AMP_Customizer' ) ) {
 		 */
 		public function validate_extra_head( $validity, $value ) {
 			if ( ! empty( $value ) ) {
-				if ( 1 === preg_match( '/<[^link|meta]/', $value ) ){
+				if ( 1 === preg_match( '/<[^link|meta]/', $value ) ) {
 					$validity->add( 'invalid-code', sprintf( esc_html( __( 'Only %1$s and %2$s tags are allowed', 'wordpress-seo' ) ), '<link>', '<meta>' ) );
 				}
 			}
@@ -119,10 +119,10 @@ if ( ! class_exists( 'YoastSEO_AMP_Customizer' ) ) {
 			if ( ! empty( $value ) ) {
 				$image_atts = wp_get_attachment_metadata( $value );
 				if ( false !== $image_atts ) {
-					if ( $image_atts['width'] < 32 || $image_atts['height'] < 32 ){
+					if ( $image_atts['width'] < 32 || $image_atts['height'] < 32 ) {
 						$validity->add( 'image-size', __( 'The amp icon needs to be at least 32px &times; 32px', 'wordpress-seo' ) );
 					}
-					if ( $image_atts['width'] !== $image_atts['height'] ){
+					if ( $image_atts['width'] !== $image_atts['height'] ) {
 						$validity->add( 'image-size', __( 'The amp icon needs to have the same width and height', 'wordpress-seo' ) );
 					}
 				}
@@ -143,7 +143,7 @@ if ( ! class_exists( 'YoastSEO_AMP_Customizer' ) ) {
 			if ( ! empty( $value ) ) {
 				$image_atts = wp_get_attachment_metadata( $value );
 				if ( false !== $image_atts && $image_atts['width'] < 696 ) {
-						$validity->add( 'image-size', __( 'The amp default image needs to be at least 696px wide', 'wordpress-seo' ) );
+					$validity->add( 'image-size', __( 'The amp default image needs to be at least 696px wide', 'wordpress-seo' ) );
 				}
 			}
 
@@ -213,10 +213,10 @@ if ( ! class_exists( 'YoastSEO_AMP_Customizer' ) ) {
 			 */
 			$wp_customize->add_setting( $this->option_name . '[amp_site_icon]', array(
 				'capability'        => 'manage_options',
-				'type'              => 'theme_mod',
+				'type'              => 'option',
 				'sanitize_callback' => 'absint',
 				// Reload the entire page to get the new icon
-				'transport'         => 'reload',
+				'transport'         => 'refresh',
 				'validate_callback' => array( $this, 'sanitize_amp_site_icon' ),
 			) );
 
@@ -242,10 +242,10 @@ if ( ! class_exists( 'YoastSEO_AMP_Customizer' ) ) {
 			 */
 			$wp_customize->add_setting( $this->option_name . '[default_image]', array(
 				'capability'        => 'manage_options',
-				'type'              => 'theme_mod',
+				'type'              => 'option',
 				'sanitize_callback' => 'absint',
 				// Reload the entire page to get the default image
-				'transport'         => 'reload',
+				'transport'         => 'refresh',
 				'validate_callback' => array( $this, 'sanitize_amp_default_image' ),
 			) );
 
@@ -317,7 +317,7 @@ if ( ! class_exists( 'YoastSEO_AMP_Customizer' ) ) {
 					'label'   => $default_labels['underline'],
 					'choices' => array(
 						'underline' => __( 'Enabled', 'wordpress-seo' ),
-						'none' => __( 'Disabled', 'wordpress-seo' ),
+						'none'      => __( 'Disabled', 'wordpress-seo' ),
 					),
 				)
 			);
@@ -422,7 +422,7 @@ if ( ! class_exists( 'YoastSEO_AMP_Customizer' ) ) {
 			$amp_post_types = get_post_types_by_support( 'amp' );
 
 			// bail on archive and other non-singular templates
-			if( !is_singular( $amp_post_types) ){
+			if ( ! is_singular( $amp_post_types ) ) {
 				return false;
 			}
 

--- a/classes/class-frontend.php
+++ b/classes/class-frontend.php
@@ -52,6 +52,52 @@ if ( ! class_exists( 'YoastSEO_AMP_Frontend' ) ) {
 		}
 
 		/**
+		 * Return CSS selector information
+		 *
+		 * @return array
+		 */
+		public function get_css_selectors() {
+			return array(
+				'header-color'            => array(
+					'selector' => 'nav.amp-wp-title-bar',
+					'property' => 'background',
+				),
+				'headings-color'          => array(
+					'selector' => '.amp-wp-title, h2, h3, h4',
+					'property' => 'color',
+				),
+				'text-color'              => array(
+					'selector' => '.amp-wp-content',
+					'property' => 'color',
+				),
+				'blockquote-bg-color'     => array(
+					'selector' => '.amp-wp-content blockquote',
+					'property' => 'background-color',
+				),
+				'blockquote-border-color' => array(
+					'selector' => '.amp-wp-content blockquote',
+					'property' => 'border-color',
+				),
+				'blockquote-text-color'   => array(
+					'selector' => '.amp-wp-content blockquote',
+					'property' => 'color',
+				),
+				'link-color'              => array(
+					'selector' => 'a, a:active, a:visited',
+					'property' => 'color',
+				),
+				'link-color-hover'        => array(
+					'selector' => 'a:hover, a:focus',
+					'property' => 'color',
+				),
+				'meta-color'              => array(
+					'selector' => '.amp-wp-meta li, .amp-wp-meta li a',
+					'property' => 'color',
+				),
+			);
+		}
+
+		/**
 		 * Add our own sanitizer to the array of sanitizers
 		 *
 		 * @param array $sanitizers
@@ -114,10 +160,12 @@ if ( ! class_exists( 'YoastSEO_AMP_Frontend' ) ) {
 					}
 					if ( $this->options[ 'post_types-' . $pt->name . '-amp' ] === 'on' ) {
 						add_post_type_support( $pt->name, AMP_QUERY_VAR );
+
 						return;
 					}
 					if ( 'post' === $pt->name ) {
 						add_action( 'wp', array( $this, 'disable_amp_for_posts' ) );
+
 						return;
 					}
 					remove_post_type_support( $pt->name, AMP_QUERY_VAR );
@@ -156,7 +204,7 @@ if ( ! class_exists( 'YoastSEO_AMP_Frontend' ) ) {
 		/**
 		 * Fix the AMP metadata for a post
 		 *
-		 * @param array $metadata
+		 * @param array   $metadata
 		 * @param WP_Post $post
 		 *
 		 * @return array
@@ -187,23 +235,17 @@ if ( ! class_exists( 'YoastSEO_AMP_Frontend' ) ) {
 			require 'views/additional-css.php';
 
 			$css_builder = new YoastSEO_AMP_CSS_Builder();
-			$css_builder->add_option( 'header-color', 'nav.amp-wp-title-bar', 'background' );
-			$css_builder->add_option( 'headings-color', '.amp-wp-title, h2, h3, h4', 'color' );
-			$css_builder->add_option( 'text-color', '.amp-wp-content', 'color' );
 
-			$css_builder->add_option( 'blockquote-bg-color', '.amp-wp-content blockquote', 'background-color' );
-			$css_builder->add_option( 'blockquote-border-color', '.amp-wp-content blockquote', 'border-color' );
-			$css_builder->add_option( 'blockquote-text-color', '.amp-wp-content blockquote', 'color' );
+			$css_selectors = $this->get_css_selectors();
 
-			$css_builder->add_option( 'link-color', 'a, a:active, a:visited', 'color' );
-			$css_builder->add_option( 'link-color-hover', 'a:hover, a:focus', 'color' );
-
-			$css_builder->add_option( 'meta-color', '.amp-wp-meta li, .amp-wp-meta li a', 'color' );
+			foreach( $css_selectors as $key => $css ){
+				$css_builder->add_option( $key, $css['selector'], $css['property'] );
+			}
 
 			echo $css_builder->build();
 
 			if ( ! empty( $this->options['extra-css'] ) ) {
-				$safe_text = strip_tags($this->options['extra-css']);
+				$safe_text = strip_tags( $this->options['extra-css'] );
 				$safe_text = wp_check_invalid_utf8( $safe_text );
 				$safe_text = _wp_specialchars( $safe_text, ENT_NOQUOTES );
 				echo $safe_text;
@@ -257,8 +299,8 @@ if ( ! class_exists( 'YoastSEO_AMP_Frontend' ) ) {
 		/**
 		 * Builds an image object array from an image URL
 		 *
-		 * @param string $image_url
-		 * @param string|array $size Optional. Image size. Accepts any valid image size, or an array of width
+		 * @param string       $image_url
+		 * @param string|array $size           Optional. Image size. Accepts any valid image size, or an array of width
 		 *                                     and height values in pixels (in that order). Default 'full'.
 		 *
 		 * @return array|false

--- a/classes/class-frontend.php
+++ b/classes/class-frontend.php
@@ -90,6 +90,10 @@ if ( ! class_exists( 'YoastSEO_AMP_Frontend' ) ) {
 					'selector' => 'a:hover, a:focus',
 					'property' => 'color',
 				),
+				'underline'              => array(
+					'selector' => 'a',
+					'property' => 'text-decoration',
+				),
 				'meta-color'              => array(
 					'selector' => '.amp-wp-meta li, .amp-wp-meta li a',
 					'property' => 'color',
@@ -190,7 +194,11 @@ if ( ! class_exists( 'YoastSEO_AMP_Frontend' ) ) {
 		public function fix_amp_post_data( $data ) {
 			$data['canonical_url'] = $this->front->canonical( false );
 			if ( ! empty( $this->options['amp_site_icon'] ) ) {
-				$data['site_icon_url'] = $this->options['amp_site_icon'];
+				$site_icon_id = $this->options['amp_site_icon'];
+				$site_icon    = wp_get_attachment_image_src( $site_icon_id, 'full' );
+				if ( ! empty( $site_icon ) ) {
+					$data['site_icon_url'] = $site_icon[0];
+				}
 			}
 
 			// If we are loading extra analytics, we need to load the module too.
@@ -238,7 +246,7 @@ if ( ! class_exists( 'YoastSEO_AMP_Frontend' ) ) {
 
 			$css_selectors = $this->get_css_selectors();
 
-			foreach( $css_selectors as $key => $css ){
+			foreach ( $css_selectors as $key => $css ) {
 				$css_builder->add_option( $key, $css['selector'], $css['property'] );
 			}
 
@@ -341,7 +349,16 @@ if ( ! class_exists( 'YoastSEO_AMP_Frontend' ) ) {
 
 			// Posts without an image fail validation in Google, leading to Search Console errors
 			if ( ! is_array( $image ) && isset( $this->options['default_image'] ) ) {
-				return $this->get_image_object( $this->options['default_image'] );
+				$default_img_id = $this->options['default_image'];
+				$default_img    = wp_get_attachment_image_src( $default_img_id, 'full' );
+				if ( is_array( $default_img ) ) {
+					return array(
+						'@type'  => 'ImageObject',
+						'url'    => $default_img[0],
+						'width'  => $default_img[1],
+						'height' => $default_img[2],
+					);
+				}
 			}
 
 			return $image;

--- a/classes/class-options.php
+++ b/classes/class-options.php
@@ -19,20 +19,6 @@ if ( ! class_exists( 'YoastSEO_AMP_Options' ) ) {
 		/** @var array Option defaults */
 		private $defaults = array(
 			'version'                 => 1,
-			'amp_site_icon'           => '',
-			'default_image'           => '',
-			'header-color'            => '',
-			'headings-color'          => '',
-			'text-color'              => '',
-			'meta-color'              => '',
-			'link-color'              => '',
-			'link-color-hover'        => '',
-			'underline'               => 'underline',
-			'blockquote-text-color'   => '',
-			'blockquote-bg-color'     => '',
-			'blockquote-border-color' => '',
-			'extra-css'               => '',
-			'extra-head'              => '',
 			'analytics-extra'         => '',
 		);
 
@@ -61,56 +47,9 @@ if ( ! class_exists( 'YoastSEO_AMP_Options' ) ) {
 		public function sanitize_options( $options ) {
 			$options['version'] = 1;
 
-			// Sanitize extra CSS field.
-			$extra_css            = strip_tags( $options['extra-css'] );
-			$extra_css            = wp_check_invalid_utf8( $extra_css );
-			$extra_css            = _wp_specialchars( $extra_css, ENT_NOQUOTES );
-			$options['extra-css'] = $extra_css;
-
-			// Only allow meta and link tags in head.
-			$options['extra-head'] = strip_tags( $options['extra-head'], '<link><meta>' );
-
-			$colors = array(
-				'header-color',
-				'headings-color',
-				'text-color',
-				'meta-color',
-				'link-color',
-				'blockquote-text-color',
-				'blockquote-bg-color',
-				'blockquote-border-color',
-			);
-
-			foreach ( $colors as $color ) {
-				$options[ $color ] = $this->sanitize_color( $options[ $color ], '' );
-			}
-
-			// Only allow 'on' or 'off'
-			foreach ( $options as $key => $value ) {
-				if ( 'post_types-' === substr( $key, 0, 11 ) ) {
-					$options[ $key ] = ( $value === 'on' ) ? 'on' : 'off';
-				}
-			}
-
 			$options['analytics-extra'] = $this->sanitize_analytics_code( $options['analytics-extra'] );
 
 			return $options;
-		}
-
-		/**
-		 * Sanitize hexadecimal color
-		 *
-		 * @param string $color   String to test for valid color.
-		 * @param string $default Value the string will get when no color is found.
-		 *
-		 * @return string Color or $default
-		 */
-		private function sanitize_color( $color, $default ) {
-			if ( preg_match( '~^#([0-9A-Fa-f]{6}|[0-9A-Fa-f]{3})$~', $color, $matches ) ) {
-				return $matches[0];
-			}
-
-			return $default;
 		}
 
 		/**

--- a/classes/views/admin-page.php
+++ b/classes/views/admin-page.php
@@ -43,64 +43,11 @@ $yform->admin_header( true, 'wpseo_amp', false, 'wpseo_amp_settings' );
 		</div>
 
 		<div id="design" class="wpseotab">
-			<h3><?php echo esc_html( __( 'Images', 'wordpress-seo' ) ); ?></h3>
-
-			<?php
-			$yform->media_input( 'amp_site_icon', __( 'AMP icon', 'wordpress-seo' ) ); ?>
-			<p class="desc"><?php echo esc_html( __( 'Must be at least 32px &times; 32px', 'wordpress-seo' ) ); ?></p>
-			<br/>
-
-			<?php
-			$yform->media_input( 'default_image', __( 'Default image', 'wordpress-seo' ) ); ?>
-			<p class="desc"><?php echo esc_html( __( 'Used when a post doesn\'t have an image associated with it.', 'wordpress-seo' ) ); ?>
-				<br><?php echo esc_html( __( 'The image must be at least 696px wide.', 'wordpress-seo' ) ) ?></p>
-			<br/>
-
-			<h3><?php echo esc_html( __( 'Content colors', 'wordpress-seo' ) ); ?></h3>
-
-			<?php
-			$this->color_picker( 'header-color', __( 'AMP Header color', 'wordpress-seo' ) );
-			$this->color_picker( 'headings-color', __( 'Title color', 'wordpress-seo' ) );
-			$this->color_picker( 'text-color', __( 'Text color', 'wordpress-seo' ) );
-			$this->color_picker( 'meta-color', __( 'Post meta info color', 'wordpress-seo' ) );
-			?>
-			<br/>
-
-			<h3><?php echo esc_html( __( 'Links', 'wordpress-seo' ) ); ?></h3>
-			<?php
-			$this->color_picker( 'link-color', __( 'Text color', 'wordpress-seo' ) );
-			$this->color_picker( 'link-color-hover', __( 'Hover color', 'wordpress-seo' ) );
-			?>
-
-			<?php $yform->light_switch( 'underline', __( 'Underline', 'wordpress-seo' ), array(
-				__( 'Underline', 'wordpress-seo' ),
-				__( 'No underline', 'wordpress-seo' )
-			) ); ?>
-
-			<br/>
-
-			<h3><?php echo esc_html( __( 'Blockquotes', 'wordpress-seo' ) ); ?></h3>
-			<?php
-			$this->color_picker( 'blockquote-text-color', __( 'Text color', 'wordpress-seo' ) );
-			$this->color_picker( 'blockquote-bg-color', __( 'Background color', 'wordpress-seo' ) );
-			$this->color_picker( 'blockquote-border-color', __( 'Border color', 'wordpress-seo' ) );
-			?>
-			<br/>
-
-			<h3><?php echo esc_html( __( 'Extra CSS', 'wordpress-seo' ) ); ?></h3>
-			<?php $yform->textarea( 'extra-css', __( 'Extra CSS', 'wordpress-seo' ), array(
-				'rows' => 5,
-				'cols' => 100
-			) ); ?>
-
-			<br/>
-
-			<h3><?php printf( esc_html( __( 'Extra code in %s', 'wordpress-seo' ) ), '<code>&lt;head&gt;</code>' ); ?></h3>
-			<p><?php echo sprintf( esc_html( __( 'Only %s and %s tags are allowed, other tags will be removed automatically.', 'wordpress-seo' ) ), '<code>meta</code>', '<code>link</code>' ) ?></p>
-			<?php $yform->textarea( 'extra-head', __( 'Extra code', 'wordpress-seo' ), array(
-				'rows' => 5,
-				'cols' => 100
-			) ); ?>
+			<h2>
+				<a href="<?php echo 'customize.php?autofocus[panel]=amp_settings&return=' . urlencode( add_query_arg( 'page', 'wpseo_amp#top#design', get_admin_url( null, 'admin.php' ) ) );?>">
+					<?php _e( 'Click here to edit the AMP design in the Customizer', 'wordpress-seo' ); ?>
+				</a>
+			</h2>
 
 		</div>
 

--- a/yoastseo-amp.php
+++ b/yoastseo-amp.php
@@ -47,7 +47,25 @@ if ( ! class_exists( 'YoastSEO_AMP', false ) ) {
 function yoast_seo_amp_glue_init() {
 	if ( defined( 'WPSEO_FILE' ) && defined( 'AMP__FILE__' ) ) {
 		new YoastSEO_AMP();
+
+		if( !defined('YoastSEO_AMP_PLUGIN_DIR' ) ){
+			define( 'YoastSEO_AMP_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
+		}
+
+		if( !defined('YoastSEO_AMP_PLUGIN_DIR_URL' ) ){
+			define( 'YoastSEO_AMP_PLUGIN_DIR_URL', plugin_dir_url( __FILE__ ) );
+		}
 	}
 }
 
 add_action( 'init', 'yoast_seo_amp_glue_init', 9 );
+
+/**
+ * Initialize the Yoast SEO AMP Glue plugin Customizer settings
+ */
+function yoast_seo_amp_glue_customizer_init(){
+	require_once( plugin_dir_path(__FILE__) . 'classes/class-customizer.php' );
+	YoastSEO_AMP_Customizer::get_instance();
+}
+
+add_action( 'after_setup_theme', 'yoast_seo_amp_glue_customizer_init' );


### PR DESCRIPTION
The WordPress Customizer provides a much better user experience than the settings API for front-end, visual changes.

With that in mind I've moved the visual AMP settings, such as color and images, to the Customizer.

Note this is blocked by [issue #477 of the `amp-wp` plugin](https://github.com/Automattic/amp-wp/issues/477). We could get around this with the `amp_post_template_footer` action hook but I would like to see if they fix the issue first.

Fixes [#30](https://github.com/Yoast/yoastseo-amp/issues/30)
