### PR TITLE
CS compliance: consistently use parenthesis when instantiating a new object

### DIFF
--- a/classes/class-frontend.php
+++ b/classes/class-frontend.php
@@ -242,7 +242,7 @@ if ( ! class_exists( 'YoastSEO_AMP_Frontend' ) ) {
 			}
 
 			if ( $options['opengraph'] === true ) {
-				$GLOBALS['wpseo_og'] = new WPSEO_OpenGraph;
+				$GLOBALS['wpseo_og'] = new WPSEO_OpenGraph();
 			}
 
 			do_action( 'wpseo_opengraph' );


### PR DESCRIPTION
Class instantiation consistency is now enforced via the `WordPress.Classes.ClassInstantiation` sniff as added in WPCS 0.12.0.