### PR TITLE
CS: don't use parentheses for include and require statements

### DIFF
--- a/classes/class-sanitizer.php
+++ b/classes/class-sanitizer.php
@@ -6,7 +6,7 @@ if ( ! defined( 'AMP__DIR__' ) ) {
 	exit();
 }
 
-require_once( AMP__DIR__ . '/includes/sanitizers/class-amp-base-sanitizer.php' );
+require_once AMP__DIR__ . '/includes/sanitizers/class-amp-base-sanitizer.php';
 
 /**
  * Strips blacklisted tags and attributes from content, on top of the ones the AMP plugin already removes.


### PR DESCRIPTION
* No functional changes
* `include` and `require` are language constructs, not functions, so there is no need to use parenthesis and not doing so will be, albeit marginally,  faster.