### PR TITLE
CS/XSS: escape all output

### DIFF
--- a/classes/class-backend.php
+++ b/classes/class-backend.php
@@ -129,7 +129,7 @@ if ( ! class_exists( 'YoastSEO_AMP_Backend', false ) ) {
 		 */
 		private function color_picker( $var, $label ) {
 			echo '<label class="checkbox" for="', esc_attr( $var ), '">', esc_html( $label ), '</label>';
-			echo '<input type="text" name="wpseo_amp[', esc_attr( $var ), ']"';
+			echo '<input type="text" name="', esc_attr( 'wpseo_amp[' . $var . ']' ), '"';
 			if ( isset( $this->options[ $var ] ) ) {
 				echo ' value="' . esc_attr( $this->options[ $var ] ) . '"';
 			}

--- a/classes/views/admin-page.php
+++ b/classes/views/admin-page.php
@@ -126,7 +126,7 @@ $yform->admin_header( true, 'wpseo_amp', false, 'wpseo_amp_settings' );
 				if ( $UA === null ) {
 					echo esc_html( __( 'Make sure to connect your Google Analytics plugin properly.', 'wordpress-seo' ) );
 				} else {
-					echo sprintf( esc_html( __( 'Pageviews will be tracked using the following account: %s.', 'wordpress-seo' ) ), '<code>' . $UA . '</code>' );
+					echo sprintf( esc_html( __( 'Pageviews will be tracked using the following account: %s.', 'wordpress-seo' ) ), '<code>' . esc_html( $UA ) . '</code>' );
 				}
 
 				echo '</p>';


### PR DESCRIPTION
### CS/XSS: always escape the complete string

When a variable is used as part of an attribute or url, it is always better to escape the whole string as that way a potential escape character just before the variable will be correctly escaped.
Without the context of the complete string, - even when the variable is escaped - it may still leave you open to security issues.

### Escape output

Just a simple escape.