### PR TITLE
CS/QA: Use strict comparisons with array functions

### DIFF
--- a/classes/class-sanitizer.php
+++ b/classes/class-sanitizer.php
@@ -126,7 +126,7 @@ class Yoast_AMP_Blacklist_Sanitizer extends AMP_Base_Sanitizer {
 	private function sanitize_cell_attribute( $node, $attribute ) {
 		$attribute_name = strtolower( $attribute->name );
 
-		if ( in_array( $attribute_name, array( 'width', 'height' ) ) ) {
+		if ( in_array( $attribute_name, array( 'width', 'height' ), true ) ) {
 			$node->removeAttribute( $attribute_name );
 		}
 	}
@@ -141,7 +141,7 @@ class Yoast_AMP_Blacklist_Sanitizer extends AMP_Base_Sanitizer {
 	private function sanitize_table_attribute( $node, $attribute ) {
 		$attribute_name = strtolower( $attribute->name );
 
-		if ( in_array( $attribute_name, array( 'border', 'cellspacing', 'cellpadding', 'summary' ) ) ) {
+		if ( in_array( $attribute_name, array( 'border', 'cellspacing', 'cellpadding', 'summary' ), true ) ) {
 			$node->removeAttribute( $attribute_name );
 		}
 	}


### PR DESCRIPTION
Strict type comparisons should be used as a rule, with loose type comparisons being the exception.
For array functions which do loose type comparisons, setting the third `$strict` parameter to `false` can be seen as a clear indication that this is a conscious, well thought out decision by the developer.
In all other cases, `$strict` `true` should be used.