### PR TITLE
CS/QA: code simplifications

### DIFF
--- a/classes/views/admin-page.php
+++ b/classes/views/admin-page.php
@@ -12,17 +12,17 @@ $yform->admin_header( true, 'wpseo_amp', false, 'wpseo_amp_settings' );
 ?>
 
 	<h2 class="nav-tab-wrapper" id="wpseo-tabs">
-		<a class="nav-tab" id="posttypes-tab" href="#top#posttypes"><?php echo esc_html( __( 'Post types', 'wordpress-seo' ) ); ?></a>
-		<a class="nav-tab" id="design-tab" href="#top#design"><?php echo esc_html( __( 'Design', 'wordpress-seo' ) ); ?></a>
-		<a class="nav-tab" id="analytics-tab" href="#top#analytics"><?php echo esc_html( __( 'Analytics', 'wordpress-seo' ) ); ?></a>
+		<a class="nav-tab" id="posttypes-tab" href="#top#posttypes"><?php esc_html_e( 'Post types', 'wordpress-seo' ); ?></a>
+		<a class="nav-tab" id="design-tab" href="#top#design"><?php esc_html_e( 'Design', 'wordpress-seo' ); ?></a>
+		<a class="nav-tab" id="analytics-tab" href="#top#analytics"><?php esc_html_e( 'Analytics', 'wordpress-seo' ); ?></a>
 	</h2>
 
 	<div class="tabwrapper">
 
 		<div id="posttypes" class="wpseotab">
-			<h2><?php echo esc_html( __( 'Post types that have AMP support', 'wordpress-seo' ) ); ?></h2>
-			<p><?php echo esc_html( __( 'Generally you\'d want this to be your news post types.', 'wordpress-seo' ) ); ?><br/>
-				<?php echo esc_html( __( 'Post is enabled by default, feel free to enable any of them.', 'wordpress-seo' ) ); ?></p>
+			<h2><?php esc_html_e( 'Post types that have AMP support', 'wordpress-seo' ); ?></h2>
+			<p><?php esc_html_e( 'Generally you\'d want this to be your news post types.', 'wordpress-seo' ); ?><br/>
+				<?php esc_html_e( 'Post is enabled by default, feel free to enable any of them.', 'wordpress-seo' ); ?></p>
 			<?php
 
 			$post_types = apply_filters( 'wpseo_sitemaps_supported_post_types', get_post_types( array( 'public' => true ), 'objects' ) );
@@ -46,8 +46,8 @@ $yform->admin_header( true, 'wpseo_amp', false, 'wpseo_amp_settings' );
 			if ( ! post_type_supports( 'page', AMP_QUERY_VAR ) ) :
 				?>
 				<br>
-				<strong><?php echo esc_html( __( 'Please note:', 'wordpress-seo' ) ); ?></strong>
-				<?php echo esc_html( __( 'Currently pages are not supported by the AMP plugin.', 'wordpress-seo' ) ); ?>
+				<strong><?php esc_html_e( 'Please note:', 'wordpress-seo' ); ?></strong>
+				<?php esc_html_e( 'Currently pages are not supported by the AMP plugin.', 'wordpress-seo' ); ?>
 				<?php
 			endif;
 			?>
@@ -55,22 +55,22 @@ $yform->admin_header( true, 'wpseo_amp', false, 'wpseo_amp_settings' );
 		</div>
 
 		<div id="design" class="wpseotab">
-			<h3><?php echo esc_html( __( 'Images', 'wordpress-seo' ) ); ?></h3>
+			<h3><?php esc_html_e( 'Images', 'wordpress-seo' ); ?></h3>
 
 			<?php
 			$yform->media_input( 'amp_site_icon', __( 'AMP icon', 'wordpress-seo' ) );
 			?>
-			<p class="desc"><?php echo esc_html( __( 'Must be at least 32px &times; 32px', 'wordpress-seo' ) ); ?></p>
+			<p class="desc"><?php esc_html_e( 'Must be at least 32px &times; 32px', 'wordpress-seo' ); ?></p>
 			<br/>
 
 			<?php
 			$yform->media_input( 'default_image', __( 'Default image', 'wordpress-seo' ) );
 			?>
-			<p class="desc"><?php echo esc_html( __( 'Used when a post doesn\'t have an image associated with it.', 'wordpress-seo' ) ); ?>
-				<br><?php echo esc_html( __( 'The image must be at least 696px wide.', 'wordpress-seo' ) ); ?></p>
+			<p class="desc"><?php esc_html_e( 'Used when a post doesn\'t have an image associated with it.', 'wordpress-seo' ); ?>
+				<br><?php esc_html_e( 'The image must be at least 696px wide.', 'wordpress-seo' ); ?></p>
 			<br/>
 
-			<h3><?php echo esc_html( __( 'Content colors', 'wordpress-seo' ) ); ?></h3>
+			<h3><?php esc_html_e( 'Content colors', 'wordpress-seo' ); ?></h3>
 
 			<?php
 			$this->color_picker( 'header-color', __( 'AMP Header color', 'wordpress-seo' ) );
@@ -80,7 +80,7 @@ $yform->admin_header( true, 'wpseo_amp', false, 'wpseo_amp_settings' );
 			?>
 			<br/>
 
-			<h3><?php echo esc_html( __( 'Links', 'wordpress-seo' ) ); ?></h3>
+			<h3><?php esc_html_e( 'Links', 'wordpress-seo' ); ?></h3>
 			<?php
 			$this->color_picker( 'link-color', __( 'Text color', 'wordpress-seo' ) );
 			$this->color_picker( 'link-color-hover', __( 'Hover color', 'wordpress-seo' ) );
@@ -99,7 +99,7 @@ $yform->admin_header( true, 'wpseo_amp', false, 'wpseo_amp_settings' );
 
 			<br/>
 
-			<h3><?php echo esc_html( __( 'Blockquotes', 'wordpress-seo' ) ); ?></h3>
+			<h3><?php esc_html_e( 'Blockquotes', 'wordpress-seo' ); ?></h3>
 			<?php
 			$this->color_picker( 'blockquote-text-color', __( 'Text color', 'wordpress-seo' ) );
 			$this->color_picker( 'blockquote-bg-color', __( 'Background color', 'wordpress-seo' ) );
@@ -107,7 +107,7 @@ $yform->admin_header( true, 'wpseo_amp', false, 'wpseo_amp_settings' );
 			?>
 			<br/>
 
-			<h3><?php echo esc_html( __( 'Extra CSS', 'wordpress-seo' ) ); ?></h3>
+			<h3><?php esc_html_e( 'Extra CSS', 'wordpress-seo' ); ?></h3>
 			<?php
 			$yform->textarea(
 				'extra-css',
@@ -121,8 +121,8 @@ $yform->admin_header( true, 'wpseo_amp', false, 'wpseo_amp_settings' );
 
 			<br/>
 
-			<h3><?php printf( esc_html( __( 'Extra code in %s', 'wordpress-seo' ) ), '<code>&lt;head&gt;</code>' ); ?></h3>
-			<p><?php echo sprintf( esc_html( __( 'Only %s and %s tags are allowed, other tags will be removed automatically.', 'wordpress-seo' ) ), '<code>meta</code>', '<code>link</code>' ); ?></p>
+			<h3><?php printf( esc_html__( 'Extra code in %s', 'wordpress-seo' ), '<code>&lt;head&gt;</code>' ); ?></h3>
+			<p><?php printf( esc_html__( 'Only %s and %s tags are allowed, other tags will be removed automatically.', 'wordpress-seo' ), '<code>meta</code>', '<code>link</code>' ); ?></p>
 			<?php
 			$yform->textarea(
 				'extra-head',
@@ -137,22 +137,22 @@ $yform->admin_header( true, 'wpseo_amp', false, 'wpseo_amp_settings' );
 		</div>
 
 		<div id="analytics" class="wpseotab">
-			<h2><?php echo esc_html( __( 'AMP Analytics', 'wordpress-seo' ) ); ?></h2>
+			<h2><?php esc_html_e( 'AMP Analytics', 'wordpress-seo' ); ?></h2>
 
 			<?php
 			if ( class_exists( 'Yoast_GA_Options' ) ) {
-				echo '<p>', esc_html( __( 'Because your Google Analytics plugin by Yoast is active, your AMP pages will also be tracked.', 'wordpress-seo' ) ), '<br>';
+				echo '<p>', esc_html__( 'Because your Google Analytics plugin by Yoast is active, your AMP pages will also be tracked.', 'wordpress-seo' ), '<br>';
 				$UA = Yoast_GA_Options::instance()->get_tracking_code();
 				if ( $UA === null ) {
-					echo esc_html( __( 'Make sure to connect your Google Analytics plugin properly.', 'wordpress-seo' ) );
+					esc_html_e( 'Make sure to connect your Google Analytics plugin properly.', 'wordpress-seo' );
 				}
 				else {
-					echo sprintf( esc_html( __( 'Pageviews will be tracked using the following account: %s.', 'wordpress-seo' ) ), '<code>' . esc_html( $UA ) . '</code>' );
+					printf( esc_html__( 'Pageviews will be tracked using the following account: %s.', 'wordpress-seo' ), '<code>' . esc_html( $UA ) . '</code>' );
 				}
 
 				echo '</p>';
 
-				echo '<p>', esc_html( __( 'Optionally you can override the default AMP tracking code with your own by putting it below:', 'wordpress-seo' ) ), '</p>';
+				echo '<p>', esc_html__( 'Optionally you can override the default AMP tracking code with your own by putting it below:', 'wordpress-seo' ), '</p>';
 				$yform->textarea(
 					'analytics-extra',
 					__( 'Analytics code', 'wordpress-seo' ),
@@ -163,7 +163,7 @@ $yform->admin_header( true, 'wpseo_amp', false, 'wpseo_amp_settings' );
 				);
 			}
 			else {
-				echo '<p>', esc_html( __( 'Optionally add a valid google analytics tracking code.', 'wordpress-seo' ) ), '</p>';
+				echo '<p>', esc_html__( 'Optionally add a valid google analytics tracking code.', 'wordpress-seo' ), '</p>';
 				$yform->textarea(
 					'analytics-extra',
 					__( 'Analytics code', 'wordpress-seo' ),


### PR DESCRIPTION
This combination of language construct and function calls:
```php
echo esc_html( __( 'something', 'domain' ) );
```
can be simplified to:
```php
esc_html_e( 'something', 'domain' );
```
Ref: https://developer.wordpress.org/reference/functions/esc_html_e/

Similarly, a `echo sprintf()` can be simplified to a `printf()`.
Ref: http://php.net/manual/en/function.printf.php