### PR TITLE
I18n: various fixes

### DIFF
--- a/classes/class-backend.php
+++ b/classes/class-backend.php
@@ -62,8 +62,8 @@ if ( ! class_exists( 'YoastSEO_AMP_Backend', false ) ) {
 
 			$sub_menu_pages[] = array(
 				'wpseo_dashboard',
-				__( 'AMP', 'wordpress-seo' ),
-				__( 'AMP', 'wordpress-seo' ),
+				__( 'AMP', 'yoastseo-amp' ),
+				__( 'AMP', 'yoastseo-amp' ),
 				'manage_options',
 				'wpseo_amp',
 				array( $this, 'display' ),
@@ -117,7 +117,7 @@ if ( ! class_exists( 'YoastSEO_AMP_Backend', false ) ) {
 		 */
 		public function localize_media_script() {
 			return array(
-				'choose_image' => __( 'Use Logo', 'wordpress-seo' ),
+				'choose_image' => __( 'Use Logo', 'yoastseo-amp' ),
 			);
 		}
 

--- a/classes/views/admin-page.php
+++ b/classes/views/admin-page.php
@@ -19,17 +19,17 @@ $yform->admin_header( true, 'wpseo_amp', false, 'wpseo_amp_settings' );
 ?>
 
 	<h2 class="nav-tab-wrapper" id="wpseo-tabs">
-		<a class="nav-tab" id="posttypes-tab" href="#top#posttypes"><?php esc_html_e( 'Post types', 'wordpress-seo' ); ?></a>
-		<a class="nav-tab" id="design-tab" href="#top#design"><?php esc_html_e( 'Design', 'wordpress-seo' ); ?></a>
-		<a class="nav-tab" id="analytics-tab" href="#top#analytics"><?php esc_html_e( 'Analytics', 'wordpress-seo' ); ?></a>
+		<a class="nav-tab" id="posttypes-tab" href="#top#posttypes"><?php esc_html_e( 'Post types', 'yoastseo-amp' ); ?></a>
+		<a class="nav-tab" id="design-tab" href="#top#design"><?php esc_html_e( 'Design', 'yoastseo-amp' ); ?></a>
+		<a class="nav-tab" id="analytics-tab" href="#top#analytics"><?php esc_html_e( 'Analytics', 'yoastseo-amp' ); ?></a>
 	</h2>
 
 	<div class="tabwrapper">
 
 		<div id="posttypes" class="wpseotab">
-			<h2><?php esc_html_e( 'Post types that have AMP support', 'wordpress-seo' ); ?></h2>
-			<p><?php esc_html_e( 'Generally you\'d want this to be your news post types.', 'wordpress-seo' ); ?><br/>
-				<?php esc_html_e( 'Post is enabled by default, feel free to enable any of them.', 'wordpress-seo' ); ?></p>
+			<h2><?php esc_html_e( 'Post types that have AMP support', 'yoastseo-amp' ); ?></h2>
+			<p><?php esc_html_e( 'Generally you\'d want this to be your news post types.', 'yoastseo-amp' ); ?><br/>
+				<?php esc_html_e( 'Post is enabled by default, feel free to enable any of them.', 'yoastseo-amp' ); ?></p>
 			<?php
 
 			$post_types = apply_filters( 'wpseo_sitemaps_supported_post_types', get_post_types( array( 'public' => true ), 'objects' ) );
@@ -42,8 +42,8 @@ $yform->admin_header( true, 'wpseo_amp', false, 'wpseo_amp_settings' );
 					$yform->toggle_switch(
 						'post_types-' . $pt->name . '-amp',
 						array(
-							'on'  => __( 'Enabled', 'wordpress-seo' ),
-							'off' => __( 'Disabled', 'wordpress-seo' ),
+							'on'  => __( 'Enabled', 'yoastseo-amp' ),
+							'off' => __( 'Disabled', 'yoastseo-amp' ),
 						),
 						$pt->labels->name . ' (<code>' . $pt->name . '</code>)'
 					);
@@ -53,8 +53,8 @@ $yform->admin_header( true, 'wpseo_amp', false, 'wpseo_amp_settings' );
 			if ( ! post_type_supports( 'page', AMP_QUERY_VAR ) ) :
 				?>
 				<br>
-				<strong><?php esc_html_e( 'Please note:', 'wordpress-seo' ); ?></strong>
-				<?php esc_html_e( 'Currently pages are not supported by the AMP plugin.', 'wordpress-seo' ); ?>
+				<strong><?php esc_html_e( 'Please note:', 'yoastseo-amp' ); ?></strong>
+				<?php esc_html_e( 'Currently pages are not supported by the AMP plugin.', 'yoastseo-amp' ); ?>
 				<?php
 			endif;
 			?>
@@ -62,63 +62,63 @@ $yform->admin_header( true, 'wpseo_amp', false, 'wpseo_amp_settings' );
 		</div>
 
 		<div id="design" class="wpseotab">
-			<h3><?php esc_html_e( 'Images', 'wordpress-seo' ); ?></h3>
+			<h3><?php esc_html_e( 'Images', 'yoastseo-amp' ); ?></h3>
 
 			<?php
-			$yform->media_input( 'amp_site_icon', __( 'AMP icon', 'wordpress-seo' ) );
+			$yform->media_input( 'amp_site_icon', __( 'AMP icon', 'yoastseo-amp' ) );
 			?>
-			<p class="desc"><?php esc_html_e( 'Must be at least 32px &times; 32px', 'wordpress-seo' ); ?></p>
+			<p class="desc"><?php esc_html_e( 'Must be at least 32px &times; 32px', 'yoastseo-amp' ); ?></p>
 			<br/>
 
 			<?php
-			$yform->media_input( 'default_image', __( 'Default image', 'wordpress-seo' ) );
+			$yform->media_input( 'default_image', __( 'Default image', 'yoastseo-amp' ) );
 			?>
-			<p class="desc"><?php esc_html_e( 'Used when a post doesn\'t have an image associated with it.', 'wordpress-seo' ); ?>
-				<br><?php esc_html_e( 'The image must be at least 696px wide.', 'wordpress-seo' ); ?></p>
+			<p class="desc"><?php esc_html_e( 'Used when a post doesn\'t have an image associated with it.', 'yoastseo-amp' ); ?>
+				<br><?php esc_html_e( 'The image must be at least 696px wide.', 'yoastseo-amp' ); ?></p>
 			<br/>
 
-			<h3><?php esc_html_e( 'Content colors', 'wordpress-seo' ); ?></h3>
+			<h3><?php esc_html_e( 'Content colors', 'yoastseo-amp' ); ?></h3>
 
 			<?php
-			$this->color_picker( 'header-color', __( 'AMP Header color', 'wordpress-seo' ) );
-			$this->color_picker( 'headings-color', __( 'Title color', 'wordpress-seo' ) );
-			$this->color_picker( 'text-color', __( 'Text color', 'wordpress-seo' ) );
-			$this->color_picker( 'meta-color', __( 'Post meta info color', 'wordpress-seo' ) );
+			$this->color_picker( 'header-color', __( 'AMP Header color', 'yoastseo-amp' ) );
+			$this->color_picker( 'headings-color', __( 'Title color', 'yoastseo-amp' ) );
+			$this->color_picker( 'text-color', __( 'Text color', 'yoastseo-amp' ) );
+			$this->color_picker( 'meta-color', __( 'Post meta info color', 'yoastseo-amp' ) );
 			?>
 			<br/>
 
-			<h3><?php esc_html_e( 'Links', 'wordpress-seo' ); ?></h3>
+			<h3><?php esc_html_e( 'Links', 'yoastseo-amp' ); ?></h3>
 			<?php
-			$this->color_picker( 'link-color', __( 'Text color', 'wordpress-seo' ) );
-			$this->color_picker( 'link-color-hover', __( 'Hover color', 'wordpress-seo' ) );
+			$this->color_picker( 'link-color', __( 'Text color', 'yoastseo-amp' ) );
+			$this->color_picker( 'link-color-hover', __( 'Hover color', 'yoastseo-amp' ) );
 			?>
 
 			<?php
 			$yform->light_switch(
 				'underline',
-				__( 'Underline', 'wordpress-seo' ),
+				__( 'Underline', 'yoastseo-amp' ),
 				array(
-					__( 'Underline', 'wordpress-seo' ),
-					__( 'No underline', 'wordpress-seo' ),
+					__( 'Underline', 'yoastseo-amp' ),
+					__( 'No underline', 'yoastseo-amp' ),
 				)
 			);
 			?>
 
 			<br/>
 
-			<h3><?php esc_html_e( 'Blockquotes', 'wordpress-seo' ); ?></h3>
+			<h3><?php esc_html_e( 'Blockquotes', 'yoastseo-amp' ); ?></h3>
 			<?php
-			$this->color_picker( 'blockquote-text-color', __( 'Text color', 'wordpress-seo' ) );
-			$this->color_picker( 'blockquote-bg-color', __( 'Background color', 'wordpress-seo' ) );
-			$this->color_picker( 'blockquote-border-color', __( 'Border color', 'wordpress-seo' ) );
+			$this->color_picker( 'blockquote-text-color', __( 'Text color', 'yoastseo-amp' ) );
+			$this->color_picker( 'blockquote-bg-color', __( 'Background color', 'yoastseo-amp' ) );
+			$this->color_picker( 'blockquote-border-color', __( 'Border color', 'yoastseo-amp' ) );
 			?>
 			<br/>
 
-			<h3><?php esc_html_e( 'Extra CSS', 'wordpress-seo' ); ?></h3>
+			<h3><?php esc_html_e( 'Extra CSS', 'yoastseo-amp' ); ?></h3>
 			<?php
 			$yform->textarea(
 				'extra-css',
-				__( 'Extra CSS', 'wordpress-seo' ),
+				__( 'Extra CSS', 'yoastseo-amp' ),
 				array(
 					'rows' => 5,
 					'cols' => 100,
@@ -128,12 +128,12 @@ $yform->admin_header( true, 'wpseo_amp', false, 'wpseo_amp_settings' );
 
 			<br/>
 
-			<h3><?php printf( esc_html__( 'Extra code in %s', 'wordpress-seo' ), '<code>&lt;head&gt;</code>' ); ?></h3>
-			<p><?php printf( esc_html__( 'Only %s and %s tags are allowed, other tags will be removed automatically.', 'wordpress-seo' ), '<code>meta</code>', '<code>link</code>' ); ?></p>
+			<h3><?php printf( esc_html__( 'Extra code in %s', 'yoastseo-amp' ), '<code>&lt;head&gt;</code>' ); ?></h3>
+			<p><?php printf( esc_html__( 'Only %s and %s tags are allowed, other tags will be removed automatically.', 'yoastseo-amp' ), '<code>meta</code>', '<code>link</code>' ); ?></p>
 			<?php
 			$yform->textarea(
 				'extra-head',
-				__( 'Extra code', 'wordpress-seo' ),
+				__( 'Extra code', 'yoastseo-amp' ),
 				array(
 					'rows' => 5,
 					'cols' => 100,
@@ -144,25 +144,25 @@ $yform->admin_header( true, 'wpseo_amp', false, 'wpseo_amp_settings' );
 		</div>
 
 		<div id="analytics" class="wpseotab">
-			<h2><?php esc_html_e( 'AMP Analytics', 'wordpress-seo' ); ?></h2>
+			<h2><?php esc_html_e( 'AMP Analytics', 'yoastseo-amp' ); ?></h2>
 
 			<?php
 			if ( class_exists( 'Yoast_GA_Options' ) ) {
-				echo '<p>', esc_html__( 'Because your Google Analytics plugin by Yoast is active, your AMP pages will also be tracked.', 'wordpress-seo' ), '<br>';
+				echo '<p>', esc_html__( 'Because your Google Analytics plugin by Yoast is active, your AMP pages will also be tracked.', 'yoastseo-amp' ), '<br>';
 				$UA = Yoast_GA_Options::instance()->get_tracking_code();
 				if ( $UA === null ) {
-					esc_html_e( 'Make sure to connect your Google Analytics plugin properly.', 'wordpress-seo' );
+					esc_html_e( 'Make sure to connect your Google Analytics plugin properly.', 'yoastseo-amp' );
 				}
 				else {
-					printf( esc_html__( 'Pageviews will be tracked using the following account: %s.', 'wordpress-seo' ), '<code>' . esc_html( $UA ) . '</code>' );
+					printf( esc_html__( 'Pageviews will be tracked using the following account: %s.', 'yoastseo-amp' ), '<code>' . esc_html( $UA ) . '</code>' );
 				}
 
 				echo '</p>';
 
-				echo '<p>', esc_html__( 'Optionally you can override the default AMP tracking code with your own by putting it below:', 'wordpress-seo' ), '</p>';
+				echo '<p>', esc_html__( 'Optionally you can override the default AMP tracking code with your own by putting it below:', 'yoastseo-amp' ), '</p>';
 				$yform->textarea(
 					'analytics-extra',
-					__( 'Analytics code', 'wordpress-seo' ),
+					__( 'Analytics code', 'yoastseo-amp' ),
 					array(
 						'rows' => 5,
 						'cols' => 100,
@@ -170,10 +170,10 @@ $yform->admin_header( true, 'wpseo_amp', false, 'wpseo_amp_settings' );
 				);
 			}
 			else {
-				echo '<p>', esc_html__( 'Optionally add a valid google analytics tracking code.', 'wordpress-seo' ), '</p>';
+				echo '<p>', esc_html__( 'Optionally add a valid google analytics tracking code.', 'yoastseo-amp' ), '</p>';
 				$yform->textarea(
 					'analytics-extra',
-					__( 'Analytics code', 'wordpress-seo' ),
+					__( 'Analytics code', 'yoastseo-amp' ),
 					array(
 						'rows' => 5,
 						'cols' => 100,

--- a/classes/views/admin-page.php
+++ b/classes/views/admin-page.php
@@ -129,7 +129,7 @@ $yform->admin_header( true, 'wpseo_amp', false, 'wpseo_amp_settings' );
 			<br/>
 
 			<h3><?php printf( esc_html__( 'Extra code in %s', 'yoastseo-amp' ), '<code>&lt;head&gt;</code>' ); ?></h3>
-			<p><?php printf( esc_html__( 'Only %s and %s tags are allowed, other tags will be removed automatically.', 'yoastseo-amp' ), '<code>meta</code>', '<code>link</code>' ); ?></p>
+			<p><?php printf( esc_html__( 'Only %1$s and %2$s tags are allowed, other tags will be removed automatically.', 'yoastseo-amp' ), '<code>meta</code>', '<code>link</code>' ); ?></p>
 			<?php
 			$yform->textarea(
 				'extra-head',

--- a/classes/views/admin-page.php
+++ b/classes/views/admin-page.php
@@ -128,8 +128,21 @@ $yform->admin_header( true, 'wpseo_amp', false, 'wpseo_amp_settings' );
 
 			<br/>
 
-			<h3><?php printf( esc_html__( 'Extra code in %s', 'yoastseo-amp' ), '<code>&lt;head&gt;</code>' ); ?></h3>
-			<p><?php printf( esc_html__( 'Only %1$s and %2$s tags are allowed, other tags will be removed automatically.', 'yoastseo-amp' ), '<code>meta</code>', '<code>link</code>' ); ?></p>
+			<h3>
+				<?php
+				/* translators: %s: 'head' - as in HTML head - wrapped in <code> tags. */
+				printf( esc_html__( 'Extra code in %s', 'yoastseo-amp' ), '<code>&lt;head&gt;</code>' );
+				?>
+			</h3>
+			<p>
+				<?php
+				printf(
+					/* translators: 1: 'meta'; 2: 'link' - both wrapped in <code> tags. */
+					esc_html__( 'Only %1$s and %2$s tags are allowed, other tags will be removed automatically.', 'yoastseo-amp' ),
+					'<code>meta</code>', '<code>link</code>'
+				);
+				?>
+			</p>
 			<?php
 			$yform->textarea(
 				'extra-head',
@@ -154,7 +167,11 @@ $yform->admin_header( true, 'wpseo_amp', false, 'wpseo_amp_settings' );
 					esc_html_e( 'Make sure to connect your Google Analytics plugin properly.', 'yoastseo-amp' );
 				}
 				else {
-					printf( esc_html__( 'Pageviews will be tracked using the following account: %s.', 'yoastseo-amp' ), '<code>' . esc_html( $UA ) . '</code>' );
+					printf(
+						/* translators: %s: google analytics tracking code. */
+						esc_html__( 'Pageviews will be tracked using the following account: %s.', 'yoastseo-amp' ),
+						'<code>' . esc_html( $UA ) . '</code>'
+					);
 				}
 
 				echo '</p>';

--- a/yoastseo-amp.php
+++ b/yoastseo-amp.php
@@ -14,6 +14,8 @@
  * Version:     0.4.2
  * Author:      Joost de Valk
  * Author URI:  https://yoast.com
+ * Text Domain: yoastseo-amp
+ * Domain Path: /languages/
  */
 
 if ( ! class_exists( 'YoastSEO_AMP', false ) ) {


### PR DESCRIPTION
### I18n: use correct text-domain

Each plugin should use its own text-domain to facilitate translations.

As this plugin depends on YoastSEO to be available, strings which are already used in YoastSEO can be re-used, if needs be, but new strings should be under the plugin's own text-domain.

N.B.: no cross-check with YoastSEO strings has been done, this commit just changes all text-domain calls to the more appropriate `yoastseo-amp`.

Fixes #42
Prepares for #53

### I18n: use numbered placeholders

When there are more than one placeholders in a text string, they should always be numbered to allow for right-to-left languages and languages where the grammar would cause the order to change.

### I18n: add missing translators comments

Includes function call layout changes for the following reasons;
* By adding the comments, the embedded PHP becomes multi-line and therefore the PHP open/close tags need to be on their own lines.
* As the code is then being reformatted anyway, addressing overly long lines is a logical next step.

