### PR TITLE
CS: rename some non-descript variables

### DIFF
--- a/classes/frontend.php
+++ b/classes/frontend.php
@@ -100,14 +100,14 @@ if ( ! class_exists( 'YoastSEO_AMP_Frontend' ) ) {
 			if ( ! class_exists( 'Yoast_GA_Options' ) || Yoast_GA_Options::instance()->get_tracking_code() === null ) {
 				return $analytics;
 			}
-			$UA = Yoast_GA_Options::instance()->get_tracking_code();
+			$tracking_code = Yoast_GA_Options::instance()->get_tracking_code();
 
 			$analytics['yst-googleanalytics'] = array(
 				'type'        => 'googleanalytics',
 				'attributes'  => array(),
 				'config_data' => array(
 					'vars'     => array(
-						'account' => $UA,
+						'account' => $tracking_code,
 					),
 					'triggers' => array(
 						'trackPageview' => array(

--- a/classes/views/admin-page.php
+++ b/classes/views/admin-page.php
@@ -162,15 +162,15 @@ $yform->admin_header( true, 'wpseo_amp', false, 'wpseo_amp_settings' );
 			<?php
 			if ( class_exists( 'Yoast_GA_Options' ) ) {
 				echo '<p>', esc_html__( 'Because your Google Analytics plugin by Yoast is active, your AMP pages will also be tracked.', 'yoastseo-amp' ), '<br>';
-				$UA = Yoast_GA_Options::instance()->get_tracking_code();
-				if ( $UA === null ) {
+				$yoastseo_amp_ga_tracking_code = Yoast_GA_Options::instance()->get_tracking_code();
+				if ( $yoastseo_amp_ga_tracking_code === null ) {
 					esc_html_e( 'Make sure to connect your Google Analytics plugin properly.', 'yoastseo-amp' );
 				}
 				else {
 					printf(
 						/* translators: %s: google analytics tracking code. */
 						esc_html__( 'Pageviews will be tracked using the following account: %s.', 'yoastseo-amp' ),
-						'<code>' . esc_html( $UA ) . '</code>'
+						'<code>' . esc_html( $yoastseo_amp_ga_tracking_code ) . '</code>'
 					);
 				}
 


### PR DESCRIPTION
Variable names should be descriptive. `$UA` is not.

For the function local variable, this is just a simple variable rename.

For the variable within the view, the variable name has also been prefixed with the plugin specific prefix.

_While the view intended to only be included from within a function call made by this plugin, there is no_ guarantee _that this is the only way it will ever be called, so variables within the view_ do _need to be prefixed._

N.B.: The prefixing of the other variables within the view will be done in a separate PR once this one has been merged as it would otherwise have an (imaginary) merge conflict.

