### PR TITLE
Address a fatal error when using 'AMP For WordPress' plugin.

### DIFF
--- a/classes/frontend.php
+++ b/classes/frontend.php
@@ -170,6 +170,9 @@ if ( ! class_exists( 'YoastSEO_AMP_Frontend' ) ) {
 		 * @return array
 		 */
 		public function fix_amp_post_data( $data ) {
+			if ( ! $this->front ) {
+				$this->front = WPSEO_Frontend::get_instance();
+			}
 			$data['canonical_url'] = $this->front->canonical( false );
 
 			if ( ! empty( $this->options['amp_site_icon'] ) ) {
@@ -193,7 +196,9 @@ if ( ! class_exists( 'YoastSEO_AMP_Frontend' ) ) {
 		 * @return array
 		 */
 		public function fix_amp_post_metadata( $metadata, $post ) {
-			$this->front = WPSEO_Frontend::get_instance();
+			if ( ! $this->front ) {
+				$this->front = WPSEO_Frontend::get_instance();
+			}
 
 			$this->build_organization_object( $metadata );
 


### PR DESCRIPTION
**Request To Consider PR**

Hello,
Could you please consider this pull request, which addresses a fatal error that appears when using the new version `0.7` of the [AMP For WordPress](https://wordpress.org/plugins/amp/) plugin?

There was a [support topic](https://wordpress.org/support/topic/the-latest-amp-plugin-cause-500-error/) for the AMP plugin that reported a fatal error:

>Fatal error: Uncaught Error: Call to a member function canonical() on null in
plugins/yoastseo-amp/classes/frontend.php on line 162

**Proposed Fix**

With the AMP plugin's new version `0.7`, the filter `'amp_post_template_metadata'` now runs after `'amp_post_template_data'`

But the method `YoastSEO_AMP_Frontend::fix_amp_post_data()` relied on `'amp_post_template_metadata'` to run earlier, in order to run `$this->front = WPSEO_Frontend::get_instance();`

So this PR assigns that object to `$this->front` in `fix_amp_post_data()`, if it wasn't already.

**Steps To Reproduce**

1. Install and activate the plugins [AMP For WordPress](https://wordpress.org/plugins/amp/), [Yoast SEO](https://wordpress.org/plugins/wordpress-seo/), and [Glue for Yoast SEO & AMP](https://wordpress.org/plugins/glue-for-yoast-seo-amp/)
2. Go to the AMP URL of a post, by appending `/amp`, `?amp`, or `&amp` to a post URL, like:
https://myexamplesite.com/example-post/amp

Expected: The post displays
Actual: There's a fatal error:

>Fatal error: Uncaught Error: Call to a member function canonical() on null in /srv/www/envi/public_html/wp-content/plugins/yoastseo-amp/classes/frontend.php on line 162

<img width="1427" alt="fatal-error-url" src="https://user-images.githubusercontent.com/4063887/39613574-cb7478a4-4f2d-11e8-83ea-a87aa342b90d.png">

