### PR TITLE
Replace deprecated method call

### DIFF
--- a/classes/blacklist-sanitizer.php
+++ b/classes/blacklist-sanitizer.php
@@ -27,7 +27,7 @@ class Yoast_AMP_Blacklist_Sanitizer extends AMP_Base_Sanitizer {
 	 * The actual sanitization function.
 	 */
 	public function sanitize() {
-		$body = $this->get_body_node();
+		$body = $this->root_element;
 		$this->strip_attributes_recursive( $body );
 	}
 


### PR DESCRIPTION
AMP for WordPress plugins's method `get_body_node()` which is a member of a class `AMP_Base_Sanitizer` is deprecated since version 0.7.0. Following the deprecated method comment it has to be replaced by calling the class variable `$root_element` instead, which I did in this case.