### PR TITLE
Composer: sync with other config files

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,11 +18,11 @@
   "type": "wordpress-plugin",
   "support": {
     "issues": "https://github.com/Yoast/yoastseo-amp/issues",
-    "forum": "https://wordpress.org/support/plugin/yoastseo-amp",
-    "wiki": "https://github.com/Yoast/yoastseo-amp/wiki",
+    "forum": "https://wordpress.org/support/plugin/glue-for-yoast-seo-amp",
     "source": "https://github.com/Yoast/yoastseo-amp"
   },
   "require": {
+    "php": ">=5.2",
     "composer/installers": "^1.5"
   },
   "require-dev": {
@@ -35,7 +35,13 @@
   "scripts": {
     "config-yoastcs": [
       "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin::run",
-      "\"vendor/bin/phpcs\" --config-set default_standard Yoast"
+      "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --config-set default_standard Yoast"
+    ],
+    "check-cs": [
+      "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs"
+    ],
+    "fix-cs": [
+      "@php ./vendor/squizlabs/php_codesniffer/bin/phpcbf"
     ]
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b1e8044440f98fbe5623eb20bd9e1648",
+    "content-hash": "6a8a7e3c90bd3454ff482cc3b71d94e9",
     "packages": [
         {
             "name": "composer/installers",
@@ -1745,6 +1745,8 @@
     },
     "prefer-stable": true,
     "prefer-lowest": false,
-    "platform": [],
+    "platform": {
+        "php": ">=5.2"
+    },
     "platform-dev": []
 }


### PR DESCRIPTION
I've done a compare between the `composer.json` config files in (nearly) all plugin repos.

This commit adds some additional properties to the config file to improve consistency with the other repos and predictability for devs.

* Adds an explicit minimum PHP version.
* Adds `check-cs` and `fix-cs` scripts for use by devs.
* Makes the existing `config-yoastcs` script respect the PHP version Composer is run on.
     See Yoast/yoastcs#114 for a more detailed explanation.
* Fix the forum URL and remove the link to the non-existent wiki.