### PR TITLE
Fix handling of image metadata in AMP v1.2.1-beta2

### DIFF
--- a/classes/frontend.php
+++ b/classes/frontend.php
@@ -347,10 +347,12 @@ if ( ! class_exists( 'YoastSEO_AMP_Frontend' ) ) {
 		 * If an OpenGraph image is available for the post, that one will be used. Otherwise, the default image is used.
 		 * If neither exist, the passed image is used instead.
 		 *
-		 * @param WP_Post    $post  The post to retrieve the image for.
-		 * @param array|null $image The currently set post image.
+		 * @param WP_Post                            $post  The post to retrieve the image for.
+		 * @param string|string[]|array|array[]|null $image The currently set post image(s). Can be either a URL string,
+		 *                                                  an array of URL strings, an array as a single ImageObject,
+		 *                                                  or an array of multiple ImageObject arrays. Null if none set.
 		 *
-		 * @return array The Schema.org-compliant image for the post.
+		 * @return string|string[]|array|array[]|null The Schema.org-compliant image for the post.
 		 */
 		private function get_image( $post, $image ) {
 			$og_image = $this->get_image_object( WPSEO_Meta::get_value( 'opengraph-image', $post->ID ) );
@@ -359,8 +361,11 @@ if ( ! class_exists( 'YoastSEO_AMP_Frontend' ) ) {
 			}
 
 			// Posts without an image fail validation in Google, leading to Search Console errors.
-			if ( ! is_array( $image ) && ! empty( $this->options['default_image'] ) ) {
-				return $this->get_image_object( $this->options['default_image'] );
+			if ( empty( $image ) && ! empty( $this->options['default_image'] ) ) {
+				$default_image = $this->get_image_object( $this->options['default_image'] );
+				if ( is_array( $default_image ) ) {
+					return $default_image;
+				}
 			}
 
 			return $image;

--- a/classes/frontend.php
+++ b/classes/frontend.php
@@ -359,7 +359,7 @@ if ( ! class_exists( 'YoastSEO_AMP_Frontend' ) ) {
 			}
 
 			// Posts without an image fail validation in Google, leading to Search Console errors.
-			if ( ! is_array( $image ) && isset( $this->options['default_image'] ) ) {
+			if ( ! is_array( $image ) && ! empty( $this->options['default_image'] ) ) {
 				return $this->get_image_object( $this->options['default_image'] );
 			}
 


### PR DESCRIPTION
## Summary

A bug was reported (https://github.com/ampproject/amp-wp/issues/3041) for the AMP plugin when the Yoast AMP Glue plugin active:

> `PHP Warning:  array_merge(): Argument #2 is not an array in /app/public/content/plugins/amp/includes/class-amp-story-media.php on line 154`

The reason is because of https://github.com/ampproject/amp-wp/pull/2930 which changed the structure of the `image` metadata from a single `ImageObject` array to instead be a simple URL string. 

This then resulted in `! is_array( $image )` being false and this condition being allowed to proceed:

https://github.com/Yoast/yoastseo-amp/blob/e53a20161bc3f4c473dc48d0a2d16251c86c0a64/classes/frontend.php#L361-L364

This then caused another problem on a default install of the Yoast AMP Glue plugin because `$this->options['default_image']` is actually an empty string (`""`) and not `null`. This then results in `$this->get_image_object( $this->options['default_image'] )` returning `false`. Then when `\AMP_Story_Media::filter_schemaorg_metadata_images()` runs, [this code](https://github.com/ampproject/amp-wp/blob/cc10a5d322eb61fa8530965cb16d5e6acaaf9b97/includes/class-amp-story-media.php#L152-L155) raises the warning because `$data['image']` is erroneously `false` because of what `\YoastSEO_AMP_Frontend::get_image()` returned:

```php
		$data['image'] = array_merge(
			array_values( self::get_story_meta_images() ),
			$data['image']
		);
```

We'll make the AMP plugin more robust by making sure it will ensure the value is an array prior to merging, but there are a couple bugfixes needed in the Yoast AMP Glue plugin which this PR addresses:

* Prevent using `default_image` when it is empty.
* Account for the supplied `image` being a URL string in addition to an array of URL strings or a singular ImageObject or array of ImageObject arrays.

This PR can be summarized in the following changelog entry:

* Improve compatibility with Schema.org image metadata generated by the AMP plugin, and prevent using default_image when empty.

## Test instructions

This PR can be tested by following these steps:

* Activate the AMP Yoast Glue plugin without any configuration.
* Activate AMP 1.2.1-beta2: https://github.com/ampproject/amp-wp/releases/tag/1.2.1-beta2
* Enable the Stories experience in the AMP Settings.
* Publish a story.
* No warnings should then appear in the log.