### PR TITLE
Stop explicit support for PHP < 5.6 / WP < 5.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: php
 dist: trusty
-sudo: false
 
 cache:
   directories:
@@ -21,20 +20,17 @@ php:
   - 7.0
   - 5.6
   - "7.4snapshot"
+  - "nightly"
 
 jobs:
   fast_finish: true
   include:
     - php: 7.3
       env: PHPCS=1 SECURITY=1
-    - php: 5.3
-      dist: precise
-    - php: 5.2
-      dist: precise
 
   allow_failures:
     # Allow failures for unstable builds.
-    - php: "7.4snapshot"
+    - php: "nightly"
 
 before_install:
   - phpenv config-rm xdebug.ini || echo 'No xdebug config.'
@@ -56,7 +52,7 @@ script:
 
 # Validate the composer.json file.
 # @link https://getcomposer.org/doc/03-cli.md#validate
-- if [[ $TRAVIS_PHP_VERSION == "5.3" || $TRAVIS_PHP_VERSION == "7.3" ]]; then composer validate --no-check-all; fi
+- if [[ $TRAVIS_PHP_VERSION == "5.6" || $TRAVIS_PHP_VERSION == "7.3" ]]; then composer validate --no-check-all; fi
 
 # Check for known security vulnerabilities in the currently locked-in dependencies.
 - if [[ "$SECURITY" == "1" ]]; then php $SECURITYCHECK_DIR/security-checker.phar -n security:check $(pwd)/composer.lock;fi

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "source": "https://github.com/Yoast/yoastseo-amp"
   },
   "require": {
-    "php": ">=5.2",
+    "php": ">=5.6",
     "composer/installers": "^1.5"
   },
   "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "710257ea507f00e0d42efbd77ab28d66",
+    "content-hash": "797525d988414d37b6b2884ee92cb050",
     "packages": [
         {
             "name": "composer/installers",
@@ -1475,7 +1475,7 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=5.2"
+        "php": ">=5.6"
     },
     "platform-dev": []
 }

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: AMP, SEO
 Requires at least: 5.2
 Tested up to: 5.3
 Stable tag: 0.5
-Requires PHP: 5.6.10
+Requires PHP: 5.6.20
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

Includes:
* Adjusting the `Requires...` info in the `readme.md` file.
* Removing builds against PHP < 5.6.
* Removing the build against PHP 7.4 from allowed failures.
* Adding back a build against PHP `nightly` (PHP 8).

As the AMP plugin does not contain unit tests, these changes can already be made and made in one go.

Also:
* Travis hasn't supported `sudo` for quite a while now, so removing it.

Related to https://github.com/Yoast/wordpress-seo/issues/13758

## Test instructions

This PR can be tested by following these steps:
* Check the detailed output of the Travis scripts to verify that all is working as expected.
