### PR TITLE
PHPCS: Update to YoastCS 2.0.0

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -100,7 +100,6 @@
 			<property name="prefixes" type="array" extend="true">
 				<element value="yoastseo_amp"/>
 				<element value="yoast_seo_amp"/>
-				<element value="wpseo_amp"/>
 			</property>
 		</properties>
 	</rule>

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -33,7 +33,15 @@
 	#############################################################################
 	-->
 
-	<rule ref="Yoast"/>
+	<rule ref="Yoast">
+		<properties>
+			<!-- Provide the plugin specific prefixes for all naming related sniffs. -->
+			<property name="prefixes" type="array">
+				<element value="Yoast\WP\AMP"/>
+				<element value="yoast_amp"/>
+			</property>
+		</properties>
+	</rule>
 
 
 	<!--
@@ -54,30 +62,14 @@
 	<rule ref="Yoast.Files.FileName">
 		<properties>
 			<!-- Don't trigger on the main file as renaming it would deactivate the plugin. -->
-			<property name="exclude" type="array">
+			<property name="excluded_files_strict_check" type="array">
 				<element value="yoastseo-amp.php"/>
 			</property>
 
 			<!-- Remove the following prefixes from the names of object structures. -->
-			<property name="prefixes" type="array">
+			<property name="oo_prefixes" type="array">
 				<element value="yoastseo_amp"/>
 				<element value="yoast_amp"/>
-			</property>
-		</properties>
-	</rule>
-
-	<!-- Verify that everything in the global namespace is prefixed with a plugin specific prefix. -->
-	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
-		<properties>
-			<!-- Provide the prefixes to look for. -->
-			<property name="prefixes" type="array">
-				<!-- Temporarily allowed until the prefixes are fixed. -->
-				<element value="yoastseo_amp"/>
-				<element value="yoast_seo_amp"/>
-				<element value="wpseo_amp"/>
-				<!-- These are the new prefixes which all code should comply with in the future. -->
-				<element value="yoast_amp"/>
-				<element value="Yoast\WP\AMP"/>
 			</property>
 		</properties>
 	</rule>
@@ -101,6 +93,17 @@
 	Adjustments which should be removed once the associated issue has been resolved.
 	#############################################################################
 	-->
+
+	<!-- Until all prefixes are fixed, some exceptions are allowed to the PrefixAllGlobals sniff. -->
+	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
+		<properties>
+			<property name="prefixes" type="array" extend="true">
+				<element value="yoastseo_amp"/>
+				<element value="yoast_seo_amp"/>
+				<element value="wpseo_amp"/>
+			</property>
+		</properties>
+	</rule>
 
 	<!-- The below exclusion has to do with appropriate sanitization and escaping
 		 of CSS and JS data for which no standard functionality exists in WP.

--- a/classes/backend.php
+++ b/classes/backend.php
@@ -33,7 +33,7 @@ if ( ! class_exists( 'YoastSEO_AMP_Backend', false ) ) {
 			// Register AMP admin page as a Yoast SEO admin page.
 			add_filter( 'wpseo_admin_pages', array( $this, 'add_admin_pages' ) );
 
-			add_filter( 'wpseo_amp_supported_post_types', array( $this, 'remove_page_post_type' ) );
+			add_filter( 'Yoast\WP\AMP\supported_post_types', array( $this, 'remove_page_post_type' ) );
 		}
 
 		/**

--- a/classes/backend.php
+++ b/classes/backend.php
@@ -28,12 +28,12 @@ if ( ! class_exists( 'YoastSEO_AMP_Backend', false ) ) {
 			$this->options = YoastSEO_AMP_Options::get();
 
 			// Add subitem to menu.
-			add_filter( 'wpseo_submenu_pages', array( $this, 'add_submenu_page' ) );
+			add_filter( 'wpseo_submenu_pages', [ $this, 'add_submenu_page' ] );
 
 			// Register AMP admin page as a Yoast SEO admin page.
-			add_filter( 'wpseo_admin_pages', array( $this, 'add_admin_pages' ) );
+			add_filter( 'wpseo_admin_pages', [ $this, 'add_admin_pages' ] );
 
-			add_filter( 'Yoast\WP\AMP\supported_post_types', array( $this, 'remove_page_post_type' ) );
+			add_filter( 'Yoast\WP\AMP\supported_post_types', [ $this, 'remove_page_post_type' ] );
 		}
 
 		/**
@@ -60,15 +60,15 @@ if ( ! class_exists( 'YoastSEO_AMP_Backend', false ) ) {
 		 */
 		public function add_submenu_page( $sub_menu_pages ) {
 
-			$sub_menu_pages[] = array(
+			$sub_menu_pages[] = [
 				'wpseo_dashboard',
 				__( 'AMP', 'yoastseo-amp' ),
 				__( 'AMP', 'yoastseo-amp' ),
 				'manage_options',
 				'wpseo_amp',
-				array( $this, 'display' ),
-				array( array( $this, 'enqueue_admin_page' ) ),
-			);
+				[ $this, 'display' ],
+				[ [ $this, 'enqueue_admin_page' ] ],
+			];
 
 			return $sub_menu_pages;
 		}
@@ -87,7 +87,7 @@ if ( ! class_exists( 'YoastSEO_AMP_Backend', false ) ) {
 			wp_enqueue_style(
 				'yoast_amp_css',
 				plugin_dir_url( __FILE__ ) . 'assets/amp-admin-page.css',
-				array( 'wp-color-picker' ),
+				[ 'wp-color-picker' ],
 				YoastSEO_AMP::VERSION
 			);
 
@@ -95,7 +95,7 @@ if ( ! class_exists( 'YoastSEO_AMP_Backend', false ) ) {
 			wp_enqueue_script(
 				'wpseo-admin-media',
 				plugin_dir_url( __FILE__ ) . 'assets/wp-seo-admin-media.js',
-				array( 'jquery', 'jquery-ui-core' ),
+				[ 'jquery', 'jquery-ui-core' ],
 				YoastSEO_AMP::VERSION,
 				true
 			);
@@ -104,7 +104,7 @@ if ( ! class_exists( 'YoastSEO_AMP_Backend', false ) ) {
 			wp_enqueue_script(
 				'yoast_amp_js',
 				plugin_dir_url( __FILE__ ) . 'assets/amp-admin-page.js',
-				array( 'jquery', 'wp-color-picker' ),
+				[ 'jquery', 'wp-color-picker' ],
 				YoastSEO_AMP::VERSION,
 				true
 			);
@@ -116,9 +116,9 @@ if ( ! class_exists( 'YoastSEO_AMP_Backend', false ) ) {
 		 * @return array
 		 */
 		public function localize_media_script() {
-			return array(
+			return [
 				'choose_image' => __( 'Use Logo', 'yoastseo-amp' ),
-			);
+			];
 		}
 
 		/**

--- a/classes/blacklist-sanitizer.php
+++ b/classes/blacklist-sanitizer.php
@@ -84,7 +84,7 @@ class Yoast_AMP_Blacklist_Sanitizer extends AMP_Base_Sanitizer {
 		foreach ( $tag_names as $tag_name ) {
 			$elements = $node->getElementsByTagName( $tag_name );
 			$length   = $elements->length;
-			if ( 0 === $length ) {
+			if ( $length === 0 ) {
 				continue;
 			}
 
@@ -93,7 +93,7 @@ class Yoast_AMP_Blacklist_Sanitizer extends AMP_Base_Sanitizer {
 				$parent_node = $element->parentNode;
 				$parent_node->removeChild( $element );
 
-				if ( 'body' !== $parent_node->nodeName && AMP_DOM_Utils::is_node_empty( $parent_node ) ) {
+				if ( $parent_node->nodeName !== 'body' && AMP_DOM_Utils::is_node_empty( $parent_node ) ) {
 					$parent_node->parentNode->removeChild( $parent_node );
 				}
 			}
@@ -111,7 +111,7 @@ class Yoast_AMP_Blacklist_Sanitizer extends AMP_Base_Sanitizer {
 	private function sanitize_a_attribute( $node, $attribute ) {
 		$attribute_name = strtolower( $attribute->name );
 
-		if ( 'rel' === $attribute_name && 'nofollow' !== $attribute->value ) {
+		if ( $attribute_name === 'rel' && $attribute->value !== 'nofollow' ) {
 			$node->removeAttribute( $attribute_name );
 		}
 	}
@@ -127,7 +127,7 @@ class Yoast_AMP_Blacklist_Sanitizer extends AMP_Base_Sanitizer {
 	private function sanitize_pre_attribute( $node, $attribute ) {
 		$attribute_name = strtolower( $attribute->name );
 
-		if ( 'line' === $attribute_name ) {
+		if ( $attribute_name === 'line' ) {
 			$node->removeAttribute( $attribute_name );
 		}
 	}

--- a/classes/blacklist-sanitizer.php
+++ b/classes/blacklist-sanitizer.php
@@ -143,7 +143,7 @@ class Yoast_AMP_Blacklist_Sanitizer extends AMP_Base_Sanitizer {
 	private function sanitize_cell_attribute( $node, $attribute ) {
 		$attribute_name = strtolower( $attribute->name );
 
-		if ( in_array( $attribute_name, array( 'width', 'height' ), true ) ) {
+		if ( in_array( $attribute_name, [ 'width', 'height' ], true ) ) {
 			$node->removeAttribute( $attribute_name );
 		}
 	}
@@ -159,7 +159,7 @@ class Yoast_AMP_Blacklist_Sanitizer extends AMP_Base_Sanitizer {
 	private function sanitize_table_attribute( $node, $attribute ) {
 		$attribute_name = strtolower( $attribute->name );
 
-		if ( in_array( $attribute_name, array( 'border', 'cellspacing', 'cellpadding', 'summary' ), true ) ) {
+		if ( in_array( $attribute_name, [ 'border', 'cellspacing', 'cellpadding', 'summary' ], true ) ) {
 			$node->removeAttribute( $attribute_name );
 		}
 	}

--- a/classes/css-builder.php
+++ b/classes/css-builder.php
@@ -19,7 +19,7 @@ if ( ! class_exists( 'YoastSEO_AMP_CSS_Builder', false ) ) {
 		 *
 		 * @var array
 		 */
-		private $items = array();
+		private $items = [];
 
 		/**
 		 * Adds the passed option to the CSS map.
@@ -31,10 +31,10 @@ if ( ! class_exists( 'YoastSEO_AMP_CSS_Builder', false ) ) {
 		 * @return void
 		 */
 		public function add_option( $option_key, $selector, $property ) {
-			$this->items[ $option_key ] = array(
+			$this->items[ $option_key ] = [
 				'selector' => $selector,
 				'property' => $property,
-			);
+			];
 		}
 
 		/**
@@ -46,7 +46,7 @@ if ( ! class_exists( 'YoastSEO_AMP_CSS_Builder', false ) ) {
 			$options = YoastSEO_AMP_Options::get();
 
 			$output = "\n";
-			$css    = array();
+			$css    = [];
 
 			$options = array_filter( $options );
 			$apply   = array_intersect_key( $this->items, $options );
@@ -55,7 +55,7 @@ if ( ! class_exists( 'YoastSEO_AMP_CSS_Builder', false ) ) {
 				foreach ( $apply as $key => $placement ) {
 
 					if ( ! isset( $css[ $placement['selector'] ] ) ) {
-						$css[ $placement['selector'] ] = array();
+						$css[ $placement['selector'] ] = [];
 					}
 
 					$css[ $placement['selector'] ][ $placement['property'] ] = $options[ $key ];

--- a/classes/frontend.php
+++ b/classes/frontend.php
@@ -387,11 +387,29 @@ if ( ! class_exists( 'YoastSEO_AMP_Frontend' ) ) {
 			/**
 			 * Filter: 'yoastseo_amp_schema_type' - Allow changing the Schema.org type for the post.
 			 *
+			 * @deprecated 0.6.0. Use the {@see 'Yoast\WP\AMP\schema_type'} filter instead.
+			 *
 			 * @api string $type The Schema.org type for the $post.
 			 *
 			 * @param WP_Post $post
 			 */
-			$type = apply_filters( 'yoastseo_amp_schema_type', $type, $post );
+			$type = apply_filters_deprecated(
+				'yoastseo_amp_schema_type',
+				array( $type, $post ),
+				'YoastSEO AMP 0.6.0',
+				'Yoast\WP\AMP\schema_type'
+			);
+
+			/**
+			 * Filter: 'Yoast\WP\AMP\schema_type' - Allow changing the Schema.org type for the post.
+			 *
+			 * @since 0.6.0
+			 *
+			 * @api string $type The Schema.org type for the $post.
+			 *
+			 * @param WP_Post $post
+			 */
+			$type = apply_filters( 'Yoast\WP\AMP\schema_type', $type, $post );
 
 			return $type;
 		}

--- a/classes/frontend.php
+++ b/classes/frontend.php
@@ -41,17 +41,17 @@ if ( ! class_exists( 'YoastSEO_AMP_Frontend' ) ) {
 		public function __construct() {
 			$this->set_options();
 
-			add_action( 'amp_init', array( $this, 'post_types' ) );
+			add_action( 'amp_init', [ $this, 'post_types' ] );
 
-			add_action( 'amp_post_template_css', array( $this, 'additional_css' ) );
-			add_action( 'amp_post_template_head', array( $this, 'extra_head' ) );
-			add_action( 'amp_post_template_footer', array( $this, 'extra_footer' ) );
+			add_action( 'amp_post_template_css', [ $this, 'additional_css' ] );
+			add_action( 'amp_post_template_head', [ $this, 'extra_head' ] );
+			add_action( 'amp_post_template_footer', [ $this, 'extra_footer' ] );
 
-			add_filter( 'amp_post_template_data', array( $this, 'fix_amp_post_data' ) );
-			add_filter( 'amp_post_template_metadata', array( $this, 'fix_amp_post_metadata' ), 10, 2 );
-			add_filter( 'amp_post_template_analytics', array( $this, 'analytics' ) );
+			add_filter( 'amp_post_template_data', [ $this, 'fix_amp_post_data' ] );
+			add_filter( 'amp_post_template_metadata', [ $this, 'fix_amp_post_metadata' ], 10, 2 );
+			add_filter( 'amp_post_template_analytics', [ $this, 'analytics' ] );
 
-			add_filter( 'amp_content_sanitizers', array( $this, 'add_sanitizer' ) );
+			add_filter( 'amp_content_sanitizers', [ $this, 'add_sanitizer' ] );
 		}
 
 		/**
@@ -74,7 +74,7 @@ if ( ! class_exists( 'YoastSEO_AMP_Frontend' ) ) {
 		public function add_sanitizer( $sanitizers ) {
 			require_once 'blacklist-sanitizer.php';
 
-			$sanitizers['Yoast_AMP_Blacklist_Sanitizer'] = array();
+			$sanitizers['Yoast_AMP_Blacklist_Sanitizer'] = [];
 
 			return $sanitizers;
 		}
@@ -104,21 +104,21 @@ if ( ! class_exists( 'YoastSEO_AMP_Frontend' ) ) {
 			}
 			$tracking_code = Yoast_GA_Options::instance()->get_tracking_code();
 
-			$analytics['yst-googleanalytics'] = array(
+			$analytics['yst-googleanalytics'] = [
 				'type'        => 'googleanalytics',
-				'attributes'  => array(),
-				'config_data' => array(
-					'vars'     => array(
+				'attributes'  => [],
+				'config_data' => [
+					'vars'     => [
 						'account' => $tracking_code,
-					),
-					'triggers' => array(
-						'trackPageview' => array(
+					],
+					'triggers' => [
+						'trackPageview' => [
 							'on'      => 'visible',
 							'request' => 'pageview',
-						),
-					),
-				),
-			);
+						],
+					],
+				],
+			];
 
 			return $analytics;
 		}
@@ -129,8 +129,8 @@ if ( ! class_exists( 'YoastSEO_AMP_Frontend' ) ) {
 		 * @return void
 		 */
 		public function post_types() {
-			$post_types = get_post_types( array( 'public' => true ), 'objects' );
-			if ( is_array( $post_types ) && $post_types !== array() ) {
+			$post_types = get_post_types( [ 'public' => true ], 'objects' );
+			if ( is_array( $post_types ) && $post_types !== [] ) {
 				foreach ( $post_types as $post_type ) {
 
 					$post_type_name = $post_type->name;
@@ -150,7 +150,7 @@ if ( ! class_exists( 'YoastSEO_AMP_Frontend' ) ) {
 					}
 
 					if ( 'post' === $post_type_name ) {
-						add_action( 'wp', array( $this, 'disable_amp_for_posts' ) );
+						add_action( 'wp', [ $this, 'disable_amp_for_posts' ] );
 						continue;
 					}
 
@@ -306,7 +306,7 @@ if ( ! class_exists( 'YoastSEO_AMP_Frontend' ) ) {
 			}
 
 			// The logo needs to be 600px wide max, 60px high max.
-			$logo = $this->get_image_object( $this->wpseo_options['company_logo'], array( 600, 60 ) );
+			$logo = $this->get_image_object( $this->wpseo_options['company_logo'], [ 600, 60 ] );
 			if ( is_array( $logo ) ) {
 				$metadata['publisher']['logo'] = $logo;
 			}
@@ -330,12 +330,12 @@ if ( ! class_exists( 'YoastSEO_AMP_Frontend' ) ) {
 			$image_src = wp_get_attachment_image_src( $image_id, $size );
 
 			if ( is_array( $image_src ) ) {
-				return array(
+				return [
 					'@type'  => 'ImageObject',
 					'url'    => $image_src[0],
 					'width'  => $image_src[1],
 					'height' => $image_src[2],
-				);
+				];
 			}
 
 			return false;
@@ -395,7 +395,7 @@ if ( ! class_exists( 'YoastSEO_AMP_Frontend' ) ) {
 			 */
 			$type = apply_filters_deprecated(
 				'yoastseo_amp_schema_type',
-				array( $type, $post ),
+				[ $type, $post ],
 				'YoastSEO AMP 0.6.0',
 				'Yoast\WP\AMP\schema_type'
 			);
@@ -423,7 +423,7 @@ if ( ! class_exists( 'YoastSEO_AMP_Frontend' ) ) {
 		 * @return array The version dependent class names.
 		 */
 		private function get_class_selectors() {
-			$selectors = array(
+			$selectors = [
 				'header-color'            => 'nav.amp-wp-title-bar',
 				'headings-color'          => '.amp-wp-title, h2, h3, h4',
 				'text-color'              => '.amp-wp-content',
@@ -436,18 +436,18 @@ if ( ! class_exists( 'YoastSEO_AMP_Frontend' ) ) {
 				'link-color-hover'        => 'a:hover, a:focus',
 
 				'meta-color'              => '.amp-wp-meta li, .amp-wp-meta li a',
-			);
+			];
 
 			// CSS classnames have been changed in version 0.4.0.
 			if ( version_compare( AMP__VERSION, '0.4.0', '>=' ) ) {
-				$selectors_v4 = array(
+				$selectors_v4 = [
 					'header-color'            => 'header.amp-wp-header, html',
 					'text-color'              => 'div.amp-wp-article',
 					'blockquote-bg-color'     => '.amp-wp-article-content blockquote',
 					'blockquote-border-color' => '.amp-wp-article-content blockquote',
 					'blockquote-text-color'   => '.amp-wp-article-content blockquote',
 					'meta-color'              => '.amp-wp-meta, .amp-wp-meta a',
-				);
+				];
 				$selectors    = array_merge( $selectors, $selectors_v4 );
 			}
 

--- a/classes/frontend.php
+++ b/classes/frontend.php
@@ -140,7 +140,7 @@ if ( ! class_exists( 'YoastSEO_AMP_Frontend' ) ) {
 					}
 
 					// If AMP page support is not present, don't allow enabling it here.
-					if ( 'page' === $post_type_name && ! post_type_supports( 'page', AMP_QUERY_VAR ) ) {
+					if ( $post_type_name === 'page' && ! post_type_supports( 'page', AMP_QUERY_VAR ) ) {
 						continue;
 					}
 
@@ -149,7 +149,7 @@ if ( ! class_exists( 'YoastSEO_AMP_Frontend' ) ) {
 						continue;
 					}
 
-					if ( 'post' === $post_type_name ) {
+					if ( $post_type_name === 'post' ) {
 						add_action( 'wp', [ $this, 'disable_amp_for_posts' ] );
 						continue;
 					}
@@ -380,7 +380,7 @@ if ( ! class_exists( 'YoastSEO_AMP_Frontend' ) ) {
 		 */
 		private function get_post_schema_type( $post ) {
 			$type = 'WebPage';
-			if ( 'post' === $post->post_type ) {
+			if ( $post->post_type === 'post' ) {
 				$type = 'Article';
 			}
 

--- a/classes/options.php
+++ b/classes/options.php
@@ -110,7 +110,7 @@ if ( ! class_exists( 'YoastSEO_AMP_Options' ) ) {
 
 			// Only allow 'on' or 'off'.
 			foreach ( $options as $key => $value ) {
-				if ( 'post_types-' === substr( $key, 0, 11 ) ) {
+				if ( substr( $key, 0, 11 ) === 'post_types-' ) {
 					$options[ $key ] = ( $value === 'on' ) ? 'on' : 'off';
 				}
 			}
@@ -223,7 +223,7 @@ if ( ! class_exists( 'YoastSEO_AMP_Options' ) ) {
 				foreach ( $post_types as $post_type ) {
 					if ( ! isset( $this->options[ 'post_types-' . $post_type->name . '-amp' ] ) ) {
 						$this->options[ 'post_types-' . $post_type->name . '-amp' ] = 'off';
-						if ( 'post' === $post_type->name ) {
+						if ( $post_type->name === 'post' ) {
 							$this->options[ 'post_types-' . $post_type->name . '-amp' ] = 'on';
 						}
 					}

--- a/classes/options.php
+++ b/classes/options.php
@@ -33,7 +33,7 @@ if ( ! class_exists( 'YoastSEO_AMP_Options' ) ) {
 		 *
 		 * @var array
 		 */
-		private $defaults = array(
+		private $defaults = [
 			'version'                 => 1,
 			'amp_site_icon'           => '',
 			'default_image'           => '',
@@ -50,7 +50,7 @@ if ( ! class_exists( 'YoastSEO_AMP_Options' ) ) {
 			'extra-css'               => '',
 			'extra-head'              => '',
 			'analytics-extra'         => '',
-		);
+		];
 
 		/**
 		 * Class instance.
@@ -64,14 +64,14 @@ if ( ! class_exists( 'YoastSEO_AMP_Options' ) ) {
 		 */
 		private function __construct() {
 			// Register settings.
-			add_action( 'admin_init', array( $this, 'register_settings' ) );
+			add_action( 'admin_init', [ $this, 'register_settings' ] );
 		}
 
 		/**
 		 * Register the premium settings.
 		 */
 		public function register_settings() {
-			register_setting( 'wpseo_amp_settings', $this->option_name, array( $this, 'sanitize_options' ) );
+			register_setting( 'wpseo_amp_settings', $this->option_name, [ $this, 'sanitize_options' ] );
 		}
 
 		/**
@@ -93,7 +93,7 @@ if ( ! class_exists( 'YoastSEO_AMP_Options' ) ) {
 			// Only allow meta and link tags in head.
 			$options['extra-head'] = strip_tags( $options['extra-head'], '<link><meta>' );
 
-			$colors = array(
+			$colors = [
 				'header-color',
 				'headings-color',
 				'text-color',
@@ -102,7 +102,7 @@ if ( ! class_exists( 'YoastSEO_AMP_Options' ) ) {
 				'blockquote-text-color',
 				'blockquote-bg-color',
 				'blockquote-border-color',
-			);
+			];
 
 			foreach ( $colors as $color ) {
 				$options[ $color ] = $this->sanitize_color( $options[ $color ], '' );
@@ -215,11 +215,11 @@ if ( ! class_exists( 'YoastSEO_AMP_Options' ) ) {
 		 * Get post types.
 		 */
 		private function update_post_type_settings() {
-			$post_type_names = array();
+			$post_type_names = [];
 
-			$post_types = get_post_types( array( 'public' => true ), 'objects' );
+			$post_types = get_post_types( [ 'public' => true ], 'objects' );
 
-			if ( is_array( $post_types ) && $post_types !== array() ) {
+			if ( is_array( $post_types ) && $post_types !== [] ) {
 				foreach ( $post_types as $post_type ) {
 					if ( ! isset( $this->options[ 'post_types-' . $post_type->name . '-amp' ] ) ) {
 						$this->options[ 'post_types-' . $post_type->name . '-amp' ] = 'off';
@@ -263,11 +263,11 @@ if ( ! class_exists( 'YoastSEO_AMP_Options' ) ) {
 				$parts,
 				1,
 				null,
-				array(
+				[
 					'<script type="application/json">',
 					trim( $json ),
 					'</script>',
-				)
+				]
 			);
 
 			return implode( "\n", $parts );

--- a/classes/views/additional-css.php
+++ b/classes/views/additional-css.php
@@ -13,5 +13,5 @@ td, th {
 }
 
 a, a:active, a:visited {
-	text-decoration: <?php echo ( ( 'underline' === $this->options['underline'] ) ? 'underline' : 'none' ); ?>;
+	text-decoration: <?php echo ( ( $this->options['underline'] === 'underline' ) ? 'underline' : 'none' ); ?>;
 }

--- a/classes/views/admin-page.php
+++ b/classes/views/admin-page.php
@@ -33,7 +33,7 @@ $yoast_amp_yform->admin_header( true, 'wpseo_amp', false, 'wpseo_amp_settings' )
 			<?php
 
 			// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- WPSEO hook.
-			$yoast_amp_post_types = apply_filters( 'wpseo_sitemaps_supported_post_types', get_post_types( array( 'public' => true ), 'objects' ) );
+			$yoast_amp_post_types = apply_filters( 'wpseo_sitemaps_supported_post_types', get_post_types( [ 'public' => true ], 'objects' ) );
 
 			/**
 			 * Allow specific AMP post type overrides, especially needed for Page support.
@@ -44,7 +44,7 @@ $yoast_amp_yform->admin_header( true, 'wpseo_amp', false, 'wpseo_amp_settings' )
 			 */
 			$yoast_amp_post_types = apply_filters_deprecated(
 				'wpseo_amp_supported_post_types',
-				array( $yoast_amp_post_types ),
+				[ $yoast_amp_post_types ],
 				'YoastSEO AMP 0.6.0',
 				'Yoast\WP\AMP\supported_post_types'
 			);
@@ -58,14 +58,14 @@ $yoast_amp_yform->admin_header( true, 'wpseo_amp', false, 'wpseo_amp_settings' )
 			 */
 			$yoast_amp_post_types = apply_filters( 'Yoast\WP\AMP\supported_post_types', $yoast_amp_post_types );
 
-			if ( is_array( $yoast_amp_post_types ) && $yoast_amp_post_types !== array() ) {
+			if ( is_array( $yoast_amp_post_types ) && $yoast_amp_post_types !== [] ) {
 				foreach ( $yoast_amp_post_types as $yoast_amp_pt ) {
 					$yoast_amp_yform->toggle_switch(
 						'post_types-' . $yoast_amp_pt->name . '-amp',
-						array(
+						[
 							'on'  => __( 'Enabled', 'yoastseo-amp' ),
 							'off' => __( 'Disabled', 'yoastseo-amp' ),
-						),
+						],
 						$yoast_amp_pt->labels->name . ' (<code>' . $yoast_amp_pt->name . '</code>)'
 					);
 				}
@@ -118,10 +118,10 @@ $yoast_amp_yform->admin_header( true, 'wpseo_amp', false, 'wpseo_amp_settings' )
 			$yoast_amp_yform->light_switch(
 				'underline',
 				__( 'Underline', 'yoastseo-amp' ),
-				array(
+				[
 					__( 'Underline', 'yoastseo-amp' ),
 					__( 'No underline', 'yoastseo-amp' ),
-				)
+				]
 			);
 			?>
 
@@ -140,10 +140,10 @@ $yoast_amp_yform->admin_header( true, 'wpseo_amp', false, 'wpseo_amp_settings' )
 			$yoast_amp_yform->textarea(
 				'extra-css',
 				__( 'Extra CSS', 'yoastseo-amp' ),
-				array(
+				[
 					'rows' => 5,
 					'cols' => 100,
-				)
+				]
 			);
 			?>
 
@@ -169,10 +169,10 @@ $yoast_amp_yform->admin_header( true, 'wpseo_amp', false, 'wpseo_amp_settings' )
 			$yoast_amp_yform->textarea(
 				'extra-head',
 				__( 'Extra code', 'yoastseo-amp' ),
-				array(
+				[
 					'rows' => 5,
 					'cols' => 100,
-				)
+				]
 			);
 			?>
 
@@ -202,10 +202,10 @@ $yoast_amp_yform->admin_header( true, 'wpseo_amp', false, 'wpseo_amp_settings' )
 				$yoast_amp_yform->textarea(
 					'analytics-extra',
 					__( 'Analytics code', 'yoastseo-amp' ),
-					array(
+					[
 						'rows' => 5,
 						'cols' => 100,
-					)
+					]
 				);
 			}
 			else {
@@ -213,10 +213,10 @@ $yoast_amp_yform->admin_header( true, 'wpseo_amp', false, 'wpseo_amp_settings' )
 				$yoast_amp_yform->textarea(
 					'analytics-extra',
 					__( 'Analytics code', 'yoastseo-amp' ),
-					array(
+					[
 						'rows' => 5,
 						'cols' => 100,
-					)
+					]
 				);
 			}
 			?>

--- a/classes/views/admin-page.php
+++ b/classes/views/admin-page.php
@@ -35,8 +35,28 @@ $yoast_amp_yform->admin_header( true, 'wpseo_amp', false, 'wpseo_amp_settings' )
 			// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- WPSEO hook.
 			$yoast_amp_post_types = apply_filters( 'wpseo_sitemaps_supported_post_types', get_post_types( array( 'public' => true ), 'objects' ) );
 
-			// Allow specific AMP post type overrides, especially needed for Page support.
-			$yoast_amp_post_types = apply_filters( 'wpseo_amp_supported_post_types', $yoast_amp_post_types );
+			/**
+			 * Allow specific AMP post type overrides, especially needed for Page support.
+			 *
+			 * @deprecated 0.6.0. Use the {@see 'Yoast\WP\AMP\supported_post_types'} filter instead.
+			 *
+			 * @param array $post_types Post types to show in the sitemap.
+			 */
+			$yoast_amp_post_types = apply_filters_deprecated(
+				'wpseo_amp_supported_post_types',
+				array( $yoast_amp_post_types ),
+				'YoastSEO AMP 0.6.0',
+				'Yoast\WP\AMP\supported_post_types'
+			);
+
+			/**
+			 * Allow specific AMP post type overrides, especially needed for Page support.
+			 *
+			 * @since 0.6.0
+			 *
+			 * @param array $post_types Post types to show in the sitemap.
+			 */
+			$yoast_amp_post_types = apply_filters( 'Yoast\WP\AMP\supported_post_types', $yoast_amp_post_types );
 
 			if ( is_array( $yoast_amp_post_types ) && $yoast_amp_post_types !== array() ) {
 				foreach ( $yoast_amp_post_types as $yoast_amp_pt ) {

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "composer/installers": "^1.5"
   },
   "require-dev": {
-    "yoast/yoastcs": "^1.3.0"
+    "yoast/yoastcs": "^2.0.0"
   },
   "minimum-stability": "dev",
   "prefer-stable": true,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cd92f48e6ee26555213d390330fe3e15",
+    "content-hash": "5b369d6478bee05797f96099dfaffd67",
     "packages": [
         {
             "name": "composer/installers",
@@ -196,16 +196,16 @@
         },
         {
             "name": "phpcompatibility/php-compatibility",
-            "version": "9.3.0",
+            "version": "9.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCompatibility/PHPCompatibility.git",
-                "reference": "06cc8d2c2ed62a70f52963dbdf5eaa1ec0fe34c5"
+                "reference": "1f37659196e4f3113ea506a7efba201c52303bf1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/06cc8d2c2ed62a70f52963dbdf5eaa1ec0fe34c5",
-                "reference": "06cc8d2c2ed62a70f52963dbdf5eaa1ec0fe34c5",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/1f37659196e4f3113ea506a7efba201c52303bf1",
+                "reference": "1f37659196e4f3113ea506a7efba201c52303bf1",
                 "shasum": ""
             },
             "require": {
@@ -230,13 +230,13 @@
             "authors": [
                 {
                     "name": "Wim Godden",
-                    "role": "lead",
-                    "homepage": "https://github.com/wimg"
+                    "homepage": "https://github.com/wimg",
+                    "role": "lead"
                 },
                 {
                     "name": "Juliette Reinders Folmer",
-                    "role": "lead",
-                    "homepage": "https://github.com/jrfnl"
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
                 },
                 {
                     "name": "Contributors",
@@ -250,20 +250,20 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2019-08-28T15:29:06+00:00"
+            "time": "2019-11-15T04:12:02+00:00"
         },
         {
             "name": "phpcompatibility/phpcompatibility-paragonie",
-            "version": "1.1.0",
+            "version": "1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie.git",
-                "reference": "b1bb79a7cab1fb856b56f1b5cf110b6e52d8e936"
+                "reference": "b862bc32f7e860d0b164b199bd995e690b4b191c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityParagonie/zipball/b1bb79a7cab1fb856b56f1b5cf110b6e52d8e936",
-                "reference": "b1bb79a7cab1fb856b56f1b5cf110b6e52d8e936",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityParagonie/zipball/b862bc32f7e860d0b164b199bd995e690b4b191c",
+                "reference": "b862bc32f7e860d0b164b199bd995e690b4b191c",
                 "shasum": ""
             },
             "require": {
@@ -302,7 +302,7 @@
                 "polyfill",
                 "standards"
             ],
-            "time": "2019-08-28T15:58:19+00:00"
+            "time": "2019-11-04T15:17:54+00:00"
         },
         {
             "name": "phpcompatibility/phpcompatibility-wp",
@@ -356,16 +356,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.4.2",
+            "version": "3.5.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "b8a7362af1cc1aadb5bd36c3defc4dda2cf5f0a8"
+                "reference": "557a1fc7ac702c66b0bbfe16ab3d55839ef724cb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/b8a7362af1cc1aadb5bd36c3defc4dda2cf5f0a8",
-                "reference": "b8a7362af1cc1aadb5bd36c3defc4dda2cf5f0a8",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/557a1fc7ac702c66b0bbfe16ab3d55839ef724cb",
+                "reference": "557a1fc7ac702c66b0bbfe16ab3d55839ef724cb",
                 "shasum": ""
             },
             "require": {
@@ -403,20 +403,20 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2019-04-10T23:49:02+00:00"
+            "time": "2019-12-04T04:46:47+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",
-            "version": "2.1.1",
+            "version": "2.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
-                "reference": "bd9c33152115e6741e3510ff7189605b35167908"
+                "reference": "f90e8692ce97b693633db7ab20bfa78d930f536a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/bd9c33152115e6741e3510ff7189605b35167908",
-                "reference": "bd9c33152115e6741e3510ff7189605b35167908",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/f90e8692ce97b693633db7ab20bfa78d930f536a",
+                "reference": "f90e8692ce97b693633db7ab20bfa78d930f536a",
                 "shasum": ""
             },
             "require": {
@@ -439,7 +439,7 @@
             "authors": [
                 {
                     "name": "Contributors",
-                    "homepage": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/graphs/contributors"
+                    "homepage": "https://github.com/WordPress/WordPress-Coding-Standards/graphs/contributors"
                 }
             ],
             "description": "PHP_CodeSniffer rules (sniffs) to enforce WordPress coding conventions",
@@ -448,30 +448,32 @@
                 "standards",
                 "wordpress"
             ],
-            "time": "2019-05-21T02:50:00+00:00"
+            "time": "2019-11-11T12:34:03+00:00"
         },
         {
             "name": "yoast/yoastcs",
-            "version": "1.3.0",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Yoast/yoastcs.git",
-                "reference": "f2e02a9d743fb1f7d9a40dbe38c64333790ffcca"
+                "reference": "2f445bea2b94cfe352e3d5c11c1fc7071ca5545a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/yoastcs/zipball/f2e02a9d743fb1f7d9a40dbe38c64333790ffcca",
-                "reference": "f2e02a9d743fb1f7d9a40dbe38c64333790ffcca",
+                "url": "https://api.github.com/repos/Yoast/yoastcs/zipball/2f445bea2b94cfe352e3d5c11c1fc7071ca5545a",
+                "reference": "2f445bea2b94cfe352e3d5c11c1fc7071ca5545a",
                 "shasum": ""
             },
             "require": {
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",
                 "php": ">=5.4",
-                "phpcompatibility/phpcompatibility-wp": "^2.0.0",
-                "squizlabs/php_codesniffer": "^3.4.2",
-                "wp-coding-standards/wpcs": "^2.1.1"
+                "phpcompatibility/phpcompatibility-wp": "^2.1.0",
+                "squizlabs/php_codesniffer": "^3.5.0",
+                "wp-coding-standards/wpcs": "^2.2.0"
             },
             "require-dev": {
+                "jakub-onderka/php-console-highlighter": "^0.4",
+                "jakub-onderka/php-parallel-lint": "^1.0",
                 "phpcompatibility/php-compatibility": "^9.2.0",
                 "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0",
                 "roave/security-advisories": "dev-master"
@@ -496,7 +498,7 @@
                 "wordpress",
                 "yoast"
             ],
-            "time": "2019-07-31T12:06:40+00:00"
+            "time": "2019-12-17T07:40:59+00:00"
         }
     ],
     "aliases": [],


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* The `wpseo_amp_supported_post_types` filter hook has been deprecated in favour of the `Yoast\WP\AMP\supported_post_types` hook.
* The `yoastseo_amp_schema_type` filter hook has been deprecated in favour of the `Yoast\WP\AMP\schema_type` hook.

## Relevant technical choices:

### PHPCS: Update to YoastCS 2.0.0

This updates the dependency in `composer.json`, as well as the PHPCS ruleset for YoastCS 2.0.0.

Includes:
* A selective update of the `composer.lock` for just YoastCS and its dependencies.

Ref: https://github.com/Yoast/yoastcs/releases/tag/2.0.0

### CS: deprecated old-style hook and add new-style hook [1]

This deprecates the `wpseo_amp_supported_post_types` filter hook in favour of the `Yoast\WP\AMP\supported_post_types` hook.

[This needs a changelog entry]

### CS: deprecated old-style hook and add new-style hook [2]

This deprecates the `yoastseo_amp_schema_type` filter hook in favour of the `Yoast\WP\AMP\schema_type` hook.

[This needs a changelog entry]

### CS: use short arrays (everywhere)

### CS: don't use Yoda conditions 

## Test instructions

This PR can be tested by following these steps:

See the test instructions in the https://github.com/Yoast/wpseo-woocommerce/pull/451 PR for guidance.
